### PR TITLE
Fix NPE by removing references to KafkaProducerTransactionalProperties && Bump version to 3.1.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.psc</groupId>
     <artifactId>psc-java-oss</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>psc-java-oss</name>
     <modules>

--- a/psc-common/pom.xml
+++ b/psc-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-examples</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <name>psc-examples</name>
 
     <properties>

--- a/psc-flink-logging/pom.xml
+++ b/psc-flink-logging/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-flink-logging</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/psc-flink/pom.xml
+++ b/psc-flink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pinterest.psc</groupId>
         <artifactId>psc-java-oss</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>psc-flink</artifactId>

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/FlinkPscProducer.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/FlinkPscProducer.java
@@ -39,7 +39,6 @@ import com.pinterest.psc.producer.Callback;
 import com.pinterest.psc.producer.PscProducer;
 import com.pinterest.psc.producer.PscProducerMessage;
 import com.pinterest.psc.producer.PscProducerTransactionalProperties;
-import com.pinterest.psc.producer.kafka.KafkaProducerTransactionalProperties;
 import com.pinterest.psc.serde.ByteArraySerializer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Internal;

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-integration-test/src/test/java/com/pinterest/psc/integration/producer/TestOneKafkaBackend.java
+++ b/psc-integration-test/src/test/java/com/pinterest/psc/integration/producer/TestOneKafkaBackend.java
@@ -21,9 +21,9 @@ import com.pinterest.psc.producer.Callback;
 import com.pinterest.psc.producer.PscBackendProducer;
 import com.pinterest.psc.producer.PscProducer;
 import com.pinterest.psc.producer.PscProducerMessage;
+import com.pinterest.psc.producer.PscProducerTransactionalProperties;
 import com.pinterest.psc.producer.PscProducerUtils;
 import com.pinterest.psc.producer.creation.PscKafkaProducerCreator;
-import com.pinterest.psc.producer.kafka.KafkaProducerTransactionalProperties;
 import com.pinterest.psc.serde.ByteArraySerializer;
 import com.pinterest.psc.serde.IntegerDeserializer;
 import com.pinterest.psc.serde.IntegerSerializer;
@@ -434,7 +434,7 @@ public class TestOneKafkaBackend {
         Collection<PscBackendProducer> backendProducers = PscProducerUtils.getBackendProducersOf(pscProducer);
         assertEquals(1, backendProducers.size());
         PscBackendProducer backendProducer = backendProducers.iterator().next();
-        KafkaProducerTransactionalProperties transactionalProperties = (KafkaProducerTransactionalProperties) backendProducer.getTransactionalProperties();
+        PscProducerTransactionalProperties transactionalProperties = backendProducer.getTransactionalProperties();
         long producerId = transactionalProperties.getProducerId();
         assertEquals(0, transactionalProperties.getEpoch());
 
@@ -450,7 +450,7 @@ public class TestOneKafkaBackend {
         backendProducers = PscProducerUtils.getBackendProducersOf(pscProducer2);
         assertEquals(1, backendProducers.size());
         backendProducer = backendProducers.iterator().next();
-        transactionalProperties = (KafkaProducerTransactionalProperties) backendProducer.getTransactionalProperties();
+        transactionalProperties = backendProducer.getTransactionalProperties();
         // it should bump the epoch each time for the same producer id
         assertEquals(producerId, transactionalProperties.getProducerId());
         assertEquals(1, transactionalProperties.getEpoch());
@@ -463,7 +463,7 @@ public class TestOneKafkaBackend {
         backendProducers = PscProducerUtils.getBackendProducersOf(pscProducer3);
         assertEquals(1, backendProducers.size());
         backendProducer = backendProducers.iterator().next();
-        transactionalProperties = (KafkaProducerTransactionalProperties) backendProducer.getTransactionalProperties();
+        transactionalProperties = backendProducer.getTransactionalProperties();
         assertEquals(producerId, transactionalProperties.getProducerId());
         assertEquals(2, transactionalProperties.getEpoch());
         pscProducer3.abortTransaction();

--- a/psc-logging/pom.xml
+++ b/psc-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/src/main/java/com/pinterest/psc/producer/kafka/KafkaProducerTransactionalProperties.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/kafka/KafkaProducerTransactionalProperties.java
@@ -2,6 +2,10 @@ package com.pinterest.psc.producer.kafka;
 
 import com.pinterest.psc.producer.PscProducerTransactionalProperties;
 
+/**
+ * Moved to PscProducerTransactionalProperties
+ */
+@Deprecated
 public class KafkaProducerTransactionalProperties extends PscProducerTransactionalProperties {
 
     public KafkaProducerTransactionalProperties(long producerId, short epoch) {

--- a/psc/src/main/java/com/pinterest/psc/producer/kafka/PscKafkaProducer.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/kafka/PscKafkaProducer.java
@@ -722,24 +722,13 @@ public class PscKafkaProducer<K, V> extends PscBackendProducer<K, V> {
             );
         }
 
-        resumeTransaction(new KafkaProducerTransactionalProperties(producerId, epoch));
+        resumeTransaction(new PscProducerTransactionalProperties(producerId, epoch));
     }
 
     @Override
     public void resumeTransaction(PscProducerTransactionalProperties pscProducerTransactionalProperties) throws ProducerException {
         if (kafkaProducer == null)
             handleUninitializedKafkaProducer("resumeTransaction()");
-
-        if (!(pscProducerTransactionalProperties instanceof KafkaProducerTransactionalProperties)) {
-            handleException(
-                    new BackendProducerException(
-                            "[Kafka] Unexpected producer transaction state type: " + pscProducerTransactionalProperties.getClass().getCanonicalName(),
-                            PscUtils.BACKEND_TYPE_KAFKA
-                    ), true
-            );
-        }
-
-        KafkaProducerTransactionalProperties kafkaProducerTransactionalProperties = (KafkaProducerTransactionalProperties) pscProducerTransactionalProperties;
 
         try {
             Object transactionManager = PscCommon.getField(kafkaProducer, "transactionManager");
@@ -758,8 +747,8 @@ public class PscKafkaProducer<K, V> extends PscBackendProducer<K, V> {
                 PscCommon.invoke(topicPartitionBookkeeper, "reset");
 
                 Object producerIdAndEpoch = PscCommon.getField(transactionManager, "producerIdAndEpoch");
-                PscCommon.setField(producerIdAndEpoch, "producerId", kafkaProducerTransactionalProperties.getProducerId());
-                PscCommon.setField(producerIdAndEpoch, "epoch", kafkaProducerTransactionalProperties.getEpoch());
+                PscCommon.setField(producerIdAndEpoch, "producerId", pscProducerTransactionalProperties.getProducerId());
+                PscCommon.setField(producerIdAndEpoch, "epoch", pscProducerTransactionalProperties.getEpoch());
 
                 PscCommon.invoke(
                         transactionManager,
@@ -791,7 +780,7 @@ public class PscKafkaProducer<K, V> extends PscBackendProducer<K, V> {
 
         Object transactionManager = PscCommon.getField(kafkaProducer, "transactionManager");
         Object producerIdAndEpoch = PscCommon.getField(transactionManager, "producerIdAndEpoch");
-        return new KafkaProducerTransactionalProperties(
+        return new PscProducerTransactionalProperties(
                 (long) PscCommon.getField(producerIdAndEpoch, "producerId"),
                 (short) PscCommon.getField(producerIdAndEpoch, "epoch")
         );


### PR DESCRIPTION
NPE likely happening due to this invalid check: https://github.com/pinterest/psc/blob/3.1/psc/src/main/java/com/pinterest/psc/producer/kafka/PscKafkaProducer.java#L733 which throws an exception without a null getCause()