### PR TITLE
Fix deserializer.open() NPE by moving its invocation to all cases; bump version to 3.1.3-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.psc</groupId>
     <artifactId>psc-java-oss</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3-RC1</version>
     <packaging>pom</packaging>
     <name>psc-java-oss</name>
     <modules>

--- a/psc-common/pom.xml
+++ b/psc-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-examples</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3-RC1</version>
     <name>psc-examples</name>
 
     <properties>

--- a/psc-flink-logging/pom.xml
+++ b/psc-flink-logging/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-flink-logging</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3-RC1</version>
 
     <dependencies>
         <dependency>

--- a/psc-flink/pom.xml
+++ b/psc-flink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pinterest.psc</groupId>
         <artifactId>psc-java-oss</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>psc-flink</artifactId>

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/FlinkPscConsumerBase.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/FlinkPscConsumerBase.java
@@ -752,11 +752,10 @@ public abstract class FlinkPscConsumerBase<T> extends RichParallelSourceFunction
                 LOG.info("Consumer subtask {} initially has no partitions to read from.",
                         getRuntimeContext().getIndexOfThisSubtask());
             }
-
-            this.deserializer.open(RuntimeContextInitializationContextAdapters.deserializationAdapter(this.getRuntimeContext(), (metricGroup) -> {
-                return metricGroup.addGroup("user");
-            }));
         }
+        this.deserializer.open(RuntimeContextInitializationContextAdapters.deserializationAdapter(this.getRuntimeContext(), (metricGroup) -> {
+            return metricGroup.addGroup("user");
+        }));
     }
 
     @Override

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-logging/pom.xml
+++ b/psc-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.1.2</version>
+        <version>3.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Currently, deserializer.open() is only invoked in fresh state condition. Move its invocation to outside the if/else condition so that it is always invoked to prevent NPE. This is only an issue for 3.x versions.

Also bump version to 3.1.3-RC1