### PR TITLE
Add an internal subscribe call to MemQ consumer's assign()

### DIFF
--- a/psc-integration-test/src/test/java/com/pinterest/psc/consumer/memq/TestPscMemqConsumer.java
+++ b/psc-integration-test/src/test/java/com/pinterest/psc/consumer/memq/TestPscMemqConsumer.java
@@ -169,6 +169,21 @@ public class TestPscMemqConsumer {
     }
 
     @Test
+    void testAssignDoesNotRequireSubscribe() throws Exception {
+        PscMemqConsumer<byte[], byte[]> pscMemqConsumer = getPscMemqConsumer(
+                "testAssignDoesNotRequireSubscribe");
+
+        pscMemqConsumer.assign(Collections.emptySet());
+
+        MemqTopicUri uri1 = MemqTopicUri.validate(TopicUri.validate(testMemqTopic1));
+        TopicUriPartition topicUriPartition = TestUtils.getFinalizedTopicUriPartition(uri1, 0);
+
+        pscMemqConsumer.assign(Sets.newHashSet(topicUriPartition));
+
+        pscMemqConsumer.close();
+    }
+
+    @Test
     void close() throws Exception {
         PscMemqConsumer<byte[], byte[]> pscMemqConsumer = getPscMemqConsumer(
                 "test_subscribeErrorScenarios");

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
@@ -181,6 +181,8 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
         currentAssignment.retainAll(topicUriPartitions);
         currentAssignment.addAll(topicUriPartitions);
         try {
+            memqConsumer.subscribe(topicUriPartitions.stream().map(TopicUriPartition::getTopicUri)
+                    .map(TopicUri::getTopic).collect(Collectors.toSet()));
             memqConsumer.assign(topicUriPartitions.stream().map(TopicUriPartition::getPartition)
                     .collect(Collectors.toList()));
         } catch (Exception exception) {


### PR DESCRIPTION
The native MemQ consumer expects an `assign` call to have a preceding `subscribe` call for the involved topics. With this PR, we implement this requirement in `PscMemqConsumer` class.

The new unit test would have failed without this addition.