### PR TITLE
Abstracting out logic for TransactionManager reflections and direct field access; Disallow >1 backendProducers to be created when PscProducer is transactional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.psc</groupId>
     <artifactId>psc-java-oss</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>psc-java-oss</name>
     <modules>

--- a/psc-common/pom.xml
+++ b/psc-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-examples</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <name>psc-examples</name>
 
     <properties>

--- a/psc-flink-logging/pom.xml
+++ b/psc-flink-logging/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-flink-logging</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/psc-flink/pom.xml
+++ b/psc-flink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pinterest.psc</groupId>
         <artifactId>psc-java-oss</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>psc-flink</artifactId>

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-integration-test/src/test/java/com/pinterest/psc/producer/TestMultiKafkaClusterBackends.java
+++ b/psc-integration-test/src/test/java/com/pinterest/psc/producer/TestMultiKafkaClusterBackends.java
@@ -40,8 +40,10 @@ public class TestMultiKafkaClusterBackends {
     private static final int partitions1 = 12;
     private static final String topic2 = "topic2";
     private static final int partitions2 = 24;
+    private static final String topic3 = "topic3";
+    private static final int partitions3 = 36;
     private KafkaCluster kafkaCluster1, kafkaCluster2;
-    private String topicUriStr1, topicUriStr2;
+    private String topicUriStr1, topicUriStr2, topicUriStr3;
 
     /**
      * Initializes two Kafka clusters that are commonly used by all tests, and creates a single topic on each.
@@ -61,10 +63,14 @@ public class TestMultiKafkaClusterBackends {
 
         kafkaCluster2 = new KafkaCluster("plaintext", "region2", "cluster2", 9092);
         topicUriStr2 = String.format("%s:%s%s:kafka:env:cloud_%s::%s:%s",
-                kafkaCluster2.getTransport(), TopicUri.SEPARATOR, TopicUri.STANDARD, kafkaCluster2.getRegion(), kafkaCluster2.getCluster(), topic1);
+                kafkaCluster2.getTransport(), TopicUri.SEPARATOR, TopicUri.STANDARD, kafkaCluster2.getRegion(), kafkaCluster2.getCluster(), topic2);
+
+        topicUriStr3 = String.format("%s:%s%s:kafka:env:cloud_%s::%s:%s",
+                kafkaCluster1.getTransport(), TopicUri.SEPARATOR, TopicUri.STANDARD, kafkaCluster1.getRegion(), kafkaCluster1.getCluster(), topic3);
 
         PscTestUtils.createTopicAndVerify(sharedKafkaTestResource1, topic1, partitions1);
         PscTestUtils.createTopicAndVerify(sharedKafkaTestResource1, topic2, partitions2);
+        PscTestUtils.createTopicAndVerify(sharedKafkaTestResource1, topic3, partitions3);
     }
 
     /**
@@ -78,11 +84,15 @@ public class TestMultiKafkaClusterBackends {
     public void tearDown() throws ExecutionException, InterruptedException {
         PscTestUtils.deleteTopicAndVerify(sharedKafkaTestResource1, topic1);
         PscTestUtils.deleteTopicAndVerify(sharedKafkaTestResource1, topic2);
+        PscTestUtils.deleteTopicAndVerify(sharedKafkaTestResource1, topic3);
         Thread.sleep(1000);
     }
 
     /**
      * Verifies that backend producers each have their own transactional states that could be different at times.
+     *
+     * Also, verifies that the PscProducer throws the appropriate exception when trying to send messages via a
+     * new backend producer while the PscProducer is already transactional.
      *
      * @throws ConfigurationException
      * @throws ProducerException
@@ -100,19 +110,43 @@ public class TestMultiKafkaClusterBackends {
         PscBackendProducer<Integer, Integer> backendProducer1 = pscProducer.getBackendProducer(topicUriStr1);
         assertEquals(PscProducer.TransactionalState.BEGUN, pscProducer.getBackendProducerState(backendProducer1));
 
-        Exception e = assertThrows(ProducerException.class, () -> pscProducer.beginTransaction());
-        assertEquals("Invalid transaction state: consecutive calls to beginTransaction().", e.getMessage());
+        PscProducerMessage<Integer, Integer> producerMessageTopic1 = new PscProducerMessage<>(topicUriStr1, 0);
+        pscProducer.send(producerMessageTopic1);
+        assertEquals(PscProducer.TransactionalState.IN_TRANSACTION, pscProducer.getBackendProducerState(backendProducer1));
 
-        PscProducerMessage<Integer, Integer> producerMessage = new PscProducerMessage<>(topicUriStr2, 0);
-        pscProducer.send(producerMessage);
+        PscProducerMessage<Integer, Integer> producerMessageTopic3 = new PscProducerMessage<>(topicUriStr3, 1);
+        pscProducer.send(producerMessageTopic3);
+        assertEquals(PscProducer.TransactionalState.IN_TRANSACTION, pscProducer.getBackendProducerState(backendProducer1));
 
-        assertEquals(2, pscProducer.getBackendProducers().size());
+        assertEquals(1, pscProducer.getBackendProducers().size());  // topic1 and topic3 belong to same cluster so there should only be one backend producer at this point
+        assertEquals(backendProducer1, pscProducer.getBackendProducers().iterator().next());
 
-        PscBackendProducer<Integer, Integer> backendProducer2 = pscProducer.getBackendProducer(topicUriStr2);
-        assertNotEquals(backendProducer1, backendProducer2);
+        assertEquals(PscProducer.TransactionalState.IN_TRANSACTION, pscProducer.getBackendProducerState(backendProducer1));
+        assertEquals(PscProducer.TransactionalState.INIT_AND_BEGUN, pscProducer.getTransactionalState());
 
+        pscProducer.commitTransaction();
+
+        assertEquals(PscProducer.TransactionalState.INIT_AND_BEGUN, pscProducer.getTransactionalState());
         assertEquals(PscProducer.TransactionalState.READY, pscProducer.getBackendProducerState(backendProducer1));
-        assertEquals(PscProducer.TransactionalState.IN_TRANSACTION, pscProducer.getBackendProducerState(backendProducer2));
+
+        pscProducer.beginTransaction();
+
+        assertEquals(PscProducer.TransactionalState.INIT_AND_BEGUN, pscProducer.getTransactionalState());
+        assertEquals(PscProducer.TransactionalState.BEGUN, pscProducer.getBackendProducerState(backendProducer1));
+
+        PscProducerMessage<Integer, Integer> producerMessageTopic2 = new PscProducerMessage<>(topicUriStr2, 0);
+        Exception e = assertThrows(ProducerException.class, () -> pscProducer.send(producerMessageTopic2));
+        assertEquals("Invalid call to send() which would have created a new backend producer. This is not allowed when the PscProducer is already transactional.", e.getMessage());
+
+        assertEquals(1, pscProducer.getBackendProducers().size());
+
+        pscProducer.send(producerMessageTopic1);    // this should go through
+        assertEquals(PscProducer.TransactionalState.INIT_AND_BEGUN, pscProducer.getTransactionalState());
+        assertEquals(PscProducer.TransactionalState.IN_TRANSACTION, pscProducer.getBackendProducerState(backendProducer1));
+
+        pscProducer.commitTransaction();
+        assertEquals(PscProducer.TransactionalState.INIT_AND_BEGUN, pscProducer.getTransactionalState());
+        assertEquals(PscProducer.TransactionalState.READY, pscProducer.getBackendProducerState(backendProducer1));
 
         pscProducer.close();
     }

--- a/psc-logging/pom.xml
+++ b/psc-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/src/main/java/com/pinterest/psc/producer/PscProducer.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/PscProducer.java
@@ -443,7 +443,8 @@ public class PscProducer<K, V> implements AutoCloseable {
     }
 
     /**
-     * Centralized logic for initializing transactions for a given backend producer
+     * Centralized logic for initializing transactions for a given backend producer.
+     * 
      * @param backendProducer the backendProducer to initialize transactions for
      * @throws ProducerException if the producer is already closed, or is not in the proper state to initialize transactions
      */

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/KafkaTransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/KafkaTransactionManagerOperator.java
@@ -12,12 +12,21 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A Kafka transaction manager operator that provides methods to interact with the transaction manager.
+ */
 public class KafkaTransactionManagerOperator implements TransactionManagerOperator {
 
     private static final String KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME = "producerIdAndEpoch";
     private static final String TRANSACTION_MANAGER_STATE_ENUM =
             "org.apache.kafka.clients.producer.internals.TransactionManager$State";
 
+    /**
+     * Returns the ProducerIdAndEpoch from the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @return the ProducerIdAndEpoch
+     */
     private ProducerIdAndEpoch getProducerIdAndEpoch(Object transactionManager) {
         ProducerIdAndEpoch producerIdAndEpoch = (ProducerIdAndEpoch) PscCommon.getField(transactionManager, KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME);
         if (producerIdAndEpoch == null) {
@@ -26,29 +35,59 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
         return producerIdAndEpoch;
     }
 
+    /**
+     * Returns the epoch from the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @return the epoch
+     */
     @Override
     public short getEpoch(Object transactionManager) {
         ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
         return (short) PscCommon.getField(producerIdAndEpoch, "epoch");
     }
 
+    /**
+     * Returns the transaction id from the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @return the transaction id
+     */
     @Override
     public String getTransactionId(Object transactionManager) {
         return (String) PscCommon.getField(transactionManager, "transactionalId");
     }
 
+    /**
+     * Returns the producer id from the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @return the producer id
+     */
     @Override
     public long getProducerId(Object transactionManager) {
         ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
         return (long) PscCommon.getField(producerIdAndEpoch, "producerId");
     }
 
+    /**
+     * Sets the epoch in the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @param epoch the epoch
+     */
     @Override
     public void setEpoch(Object transactionManager, short epoch) {
         ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
         PscCommon.setField(producerIdAndEpoch, "epoch", epoch);
     }
 
+    /**
+     * Sets the transaction id in the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @param transactionId the transaction id
+     */
     @Override
     public void setTransactionId(Object transactionManager, String transactionId) {
         PscCommon.setField(transactionManager, "transactionalId", transactionId);
@@ -58,12 +97,30 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
                 getTransactionManagerState("UNINITIALIZED"));
     }
 
+    /**
+     * Sets the producer id in the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @param producerId the producer id
+     */
     @Override
     public void setProducerId(Object transactionManager, long producerId) {
         ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
         PscCommon.setField(producerIdAndEpoch, "producerId", producerId);
     }
 
+    /**
+     * Enqueues in-flight transactions at the transaction manager. This method is used to ensure that
+     * in-flight transactions are flushed before the producer is closed.
+     *
+     * Calling the {@link Future#get()} method will block until the {@link TransactionalRequestResult} is completed.
+     * The {@link TransactionalRequestResult} is completed when the transaction manager has successfully enqueued the
+     * new partitions. The boolean value returned by the {@link Future#get()} method indicates whether the operation
+     * was successful.
+     *
+     * @param transactionManager the transaction manager
+     * @return a future that can be used to wait for the operation to complete.
+     */
     @Override
     public Future<Boolean> enqueueInFlightTransactions(Object transactionManager) {
         TransactionalRequestResult result = enqueueNewPartitions(transactionManager);
@@ -97,6 +154,13 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
         };
     }
 
+    /**
+     * Returns the transaction manager state given an enum name as a String.
+     *
+     * @param enumName the enum name String
+     * @return the transaction manager state enum
+     */
+    @SuppressWarnings("unchecked")
     private Enum<?> getTransactionManagerState(String enumName) {
         try {
             Class<Enum> cl = (Class<Enum>) Class.forName(TRANSACTION_MANAGER_STATE_ENUM);
@@ -143,6 +207,14 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
         return result;
     }
 
+    /**
+     * Resumes the transaction in the transaction manager by setting the producer id and epoch in the transactionManager
+     * to what is provided by the {@link PscProducerTransactionalProperties} and transitioning the transactionManager
+     * state, first to "INITIALIZING", then to "READY", and finally to "IN_TRANSACTION".
+     *
+     * @param transactionManager the transaction manager
+     * @param transactionalProperties the transactional properties containing the producerId and epoch to resume the transaction with
+     */
     @Override
     public void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties) {
         Object topicPartitionBookkeeper =
@@ -162,6 +234,13 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
         PscCommon.setField(transactionManager, "transactionStarted", true);
     }
 
+    /**
+     * Creates a {@link ProducerIdAndEpoch} object with the given producerId and epoch.
+     *
+     * @param producerId the producer id
+     * @param epoch the epoch
+     * @return the producer id and epoch object
+     */
     private ProducerIdAndEpoch createProducerIdAndEpoch(long producerId, short epoch) {
         try {
             Field field =
@@ -179,6 +258,12 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
         }
     }
 
+    /**
+     * Transitions the transaction manager state to the given state.
+     *
+     * @param transactionManager the transaction manager
+     * @param state the state to transition to
+     */
     private void transitionTransactionManagerStateTo(
             Object transactionManager, String state) {
         PscCommon.invoke(transactionManager, "transitionTo", getTransactionManagerState(state));

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/KafkaTransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/KafkaTransactionManagerOperator.java
@@ -1,0 +1,186 @@
+package com.pinterest.psc.producer.transaction;
+
+import com.pinterest.psc.common.PscCommon;
+import com.pinterest.psc.producer.PscProducerTransactionalProperties;
+import org.apache.kafka.clients.producer.internals.TransactionManager;
+import org.apache.kafka.clients.producer.internals.TransactionalRequestResult;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaTransactionManagerOperator implements TransactionManagerOperator {
+
+    private static final String KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME = "producerIdAndEpoch";
+    private static final String TRANSACTION_MANAGER_STATE_ENUM =
+            "org.apache.kafka.clients.producer.internals.TransactionManager$State";
+
+    private ProducerIdAndEpoch getProducerIdAndEpoch(Object transactionManager) {
+        ProducerIdAndEpoch producerIdAndEpoch = (ProducerIdAndEpoch) PscCommon.getField(transactionManager, KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME);
+        if (producerIdAndEpoch == null) {
+            throw new IllegalStateException("ProducerIdAndEpoch is null");
+        }
+        return producerIdAndEpoch;
+    }
+
+    @Override
+    public short getEpoch(Object transactionManager) {
+        ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
+        return (short) PscCommon.getField(producerIdAndEpoch, "epoch");
+    }
+
+    @Override
+    public String getTransactionId(Object transactionManager) {
+        return (String) PscCommon.getField(transactionManager, "transactionalId");
+    }
+
+    @Override
+    public long getProducerId(Object transactionManager) {
+        ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
+        return (long) PscCommon.getField(producerIdAndEpoch, "producerId");
+    }
+
+    @Override
+    public void setEpoch(Object transactionManager, short epoch) {
+        ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
+        PscCommon.setField(producerIdAndEpoch, "epoch", epoch);
+    }
+
+    @Override
+    public void setTransactionId(Object transactionManager, String transactionId) {
+        PscCommon.setField(transactionManager, "transactionalId", transactionId);
+        PscCommon.setField(
+                transactionManager,
+                "currentState",
+                getTransactionManagerState("UNINITIALIZED"));
+    }
+
+    @Override
+    public void setProducerId(Object transactionManager, long producerId) {
+        ProducerIdAndEpoch producerIdAndEpoch = getProducerIdAndEpoch(transactionManager);
+        PscCommon.setField(producerIdAndEpoch, "producerId", producerId);
+    }
+
+    @Override
+    public Future<Boolean> enqueueInFlightTransactions(Object transactionManager) {
+        TransactionalRequestResult result = enqueueNewPartitions(transactionManager);
+        return new Future<Boolean>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return result.isCompleted();
+            }
+
+            @Override
+            public Boolean get() {
+                result.await();
+                return result.isSuccessful();
+            }
+
+            @Override
+            public Boolean get(long timeout, TimeUnit unit) {
+                result.await(timeout, unit);
+                return result.isSuccessful();
+            }
+        };
+    }
+
+    private Enum<?> getTransactionManagerState(String enumName) {
+        try {
+            Class<Enum> cl = (Class<Enum>) Class.forName(TRANSACTION_MANAGER_STATE_ENUM);
+            return Enum.valueOf(cl, enumName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Incompatible KafkaProducer version", e);
+        }
+    }
+
+    /**
+     * Enqueues new transactions at the transaction manager and returns a {@link
+     * TransactionalRequestResult} that allows waiting on them.
+     *
+     * <p>If there are no new transactions we return a {@link TransactionalRequestResult} that is
+     * already done.
+     */
+    private TransactionalRequestResult enqueueNewPartitions(Object transactionManager) {
+        Object newPartitionsInTransaction =
+                PscCommon.getField(transactionManager, "newPartitionsInTransaction");
+        Object newPartitionsInTransactionIsEmpty =
+                PscCommon.invoke(newPartitionsInTransaction, "isEmpty");
+        TransactionalRequestResult result;
+        if (newPartitionsInTransactionIsEmpty instanceof Boolean
+                && !((Boolean) newPartitionsInTransactionIsEmpty)) {
+            Object txnRequestHandler =
+                    PscCommon.invoke(transactionManager, "addPartitionsToTransactionHandler");
+            PscCommon.invoke(
+                    transactionManager,
+                    "enqueueRequest",
+                    new Class[] {txnRequestHandler.getClass().getSuperclass()},
+                    new Object[] {txnRequestHandler});
+            result =
+                    (TransactionalRequestResult)
+                            PscCommon.getField(
+                                    txnRequestHandler,
+                                    txnRequestHandler.getClass().getSuperclass(),
+                                    "result");
+        } else {
+            // we don't have an operation but this operation string is also used in
+            // addPartitionsToTransactionHandler.
+            result = new TransactionalRequestResult("AddPartitionsToTxn");
+            result.done();
+        }
+        return result;
+    }
+
+    @Override
+    public void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties) {
+        Object topicPartitionBookkeeper =
+                PscCommon.getField(transactionManager, "topicPartitionBookkeeper");
+
+        transitionTransactionManagerStateTo(transactionManager, "INITIALIZING");
+        PscCommon.invoke(topicPartitionBookkeeper, "reset");
+
+        PscCommon.setField(
+                transactionManager,
+                KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME,
+                createProducerIdAndEpoch(transactionalProperties.getProducerId(), transactionalProperties.getEpoch()));
+
+        transitionTransactionManagerStateTo(transactionManager, "READY");
+
+        transitionTransactionManagerStateTo(transactionManager, "IN_TRANSACTION");
+        PscCommon.setField(transactionManager, "transactionStarted", true);
+    }
+
+    private ProducerIdAndEpoch createProducerIdAndEpoch(long producerId, short epoch) {
+        try {
+            Field field =
+                    TransactionManager.class.getDeclaredField(KAFKA_TXN_MANAGER_PRODUCER_ID_AND_EPOCH_FIELD_NAME);
+            Class<?> clazz = field.getType();
+            Constructor<?> constructor = clazz.getDeclaredConstructor(Long.TYPE, Short.TYPE);
+            constructor.setAccessible(true);
+            return (ProducerIdAndEpoch) constructor.newInstance(producerId, epoch);
+        } catch (InvocationTargetException
+                 | InstantiationException
+                 | IllegalAccessException
+                 | NoSuchFieldException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Incompatible KafkaProducer version", e);
+        }
+    }
+
+    private void transitionTransactionManagerStateTo(
+            Object transactionManager, String state) {
+        PscCommon.invoke(transactionManager, "transitionTo", getTransactionManagerState(state));
+    }
+}

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Future;
 
 /**
  * Backend-agnostic interface for operating on a transaction manager.
+ * See {@link TransactionManagerUtils} for more details.
  */
 public interface TransactionManagerOperator {
 

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
@@ -1,0 +1,24 @@
+package com.pinterest.psc.producer.transaction;
+
+import com.pinterest.psc.producer.PscProducerTransactionalProperties;
+
+import java.util.concurrent.Future;
+
+public interface TransactionManagerOperator {
+
+    short getEpoch(Object transactionManager);
+
+    String getTransactionId(Object transactionManager);
+
+    long getProducerId(Object transactionManager);
+
+    void setEpoch(Object transactionManager, short epoch);
+
+    void setTransactionId(Object transactionManager, String transactionId);
+
+    void setProducerId(Object transactionManager, long producerId);
+
+    Future<Boolean> enqueueInFlightTransactions(Object transactionManager);
+
+    void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties);
+}

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
@@ -4,6 +4,9 @@ import com.pinterest.psc.producer.PscProducerTransactionalProperties;
 
 import java.util.concurrent.Future;
 
+/**
+ * Backend-agnostic interface for operating on a transaction manager.
+ */
 public interface TransactionManagerOperator {
 
     short getEpoch(Object transactionManager);

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerOperator.java
@@ -25,4 +25,6 @@ public interface TransactionManagerOperator {
     Future<Boolean> enqueueInFlightTransactions(Object transactionManager);
 
     void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties);
+
+    int getTransactionCoordinatorId(Object transactionManager);
 }

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -1,6 +1,7 @@
 package com.pinterest.psc.producer.transaction;
 
 import com.pinterest.psc.producer.PscProducerTransactionalProperties;
+import com.pinterest.psc.producer.transaction.kafka.KafkaTransactionManagerOperator;
 import org.apache.kafka.clients.producer.internals.TransactionManager;
 
 import java.util.HashMap;

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -1,0 +1,57 @@
+package com.pinterest.psc.producer.transaction;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.pinterest.psc.producer.PscProducerTransactionalProperties;
+import org.apache.kafka.clients.producer.internals.TransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class TransactionManagerUtils {
+
+    private static final Map<String, TransactionManagerOperator> TXN_MANAGER_CLASSNAME_TO_OPERATOR = new HashMap<>();
+
+    private static TransactionManagerOperator getOrCreateTransactionManagerOperator(Object transactionManager) {
+        return TXN_MANAGER_CLASSNAME_TO_OPERATOR.computeIfAbsent(transactionManager.getClass().getName(), className -> {
+            if (className.equals(TransactionManager.class.getName())) {
+                return new KafkaTransactionManagerOperator();
+            }
+            throw new IllegalArgumentException("Unsupported transaction manager class: " + className);
+        });
+    }
+
+    public static short getEpoch(Object transactionManager) {
+        return getOrCreateTransactionManagerOperator(transactionManager).getEpoch(transactionManager);
+    }
+
+    public static long getProducerId(Object transactionManager) {
+        return getOrCreateTransactionManagerOperator(transactionManager).getProducerId(transactionManager);
+    }
+
+    public static String getTransactionId(Object transactionManager) {
+        return getOrCreateTransactionManagerOperator(transactionManager).getTransactionId(transactionManager);
+    }
+
+    public static void setEpoch(Object transactionManager, short epoch) {
+        getOrCreateTransactionManagerOperator(transactionManager).setEpoch(transactionManager, epoch);
+    }
+
+    public static void setProducerId(Object transactionManager, long producerId) {
+        getOrCreateTransactionManagerOperator(transactionManager).setProducerId(transactionManager, producerId);
+    }
+
+    public static void setTransactionId(Object transactionManager, String transactionalId) {
+        getOrCreateTransactionManagerOperator(transactionManager).setTransactionId(transactionManager, transactionalId);
+    }
+
+    public static Future<Boolean> enqueueInFlightTransactions(Object transactionManager) {
+        return getOrCreateTransactionManagerOperator(transactionManager).enqueueInFlightTransactions(transactionManager);
+    }
+
+    public static void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties) {
+        getOrCreateTransactionManagerOperator(transactionManager).resumeTransaction(transactionManager, transactionalProperties);
+    }
+
+
+}

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -15,7 +15,7 @@ import java.util.concurrent.Future;
  * For regular transaction operations like beginTransaction, commitTransaction, and abortTransaction, they are not included here
  * because they should be directly accessible via public APIs of the backend producer implementation.
  *
- * Each backend PubSub implementation should provide a TransactionManagerOperator implementation to support the operations,
+ * Each backend PubSub implementation should provide a {@link TransactionManagerOperator} implementation to support the operations,
  * and register it in the TXN_MANAGER_CLASSNAME_TO_OPERATOR map.
  */
 public class TransactionManagerUtils {

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -102,7 +102,9 @@ public class TransactionManagerUtils {
     }
 
     /**
-     * Resume the transaction in the transaction manager.
+     * Resume the transaction in the transaction manager with the given transactional properties. Typically,
+     * this is used to resume a transaction with the same transaction ID and producer ID after a previous transaction
+     * has been aborted or failed.
      *
      * @param transactionManager the transaction manager object
      * @param transactionalProperties the transactional properties

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -113,4 +113,14 @@ public class TransactionManagerUtils {
     public static void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties) {
         getOrCreateTransactionManagerOperator(transactionManager).resumeTransaction(transactionManager, transactionalProperties);
     }
+
+    /**
+     * Get the transaction coordinator ID of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @return the transaction coordinator ID of the transaction manager
+     */
+    public static int getTransactionCoordinatorId(Object transactionManager) {
+        return getOrCreateTransactionManagerOperator(transactionManager).getTransactionCoordinatorId(transactionManager);
+    }
 }

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/TransactionManagerUtils.java
@@ -1,6 +1,5 @@
 package com.pinterest.psc.producer.transaction;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.pinterest.psc.producer.PscProducerTransactionalProperties;
 import org.apache.kafka.clients.producer.internals.TransactionManager;
 
@@ -8,6 +7,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+/**
+ * This class is used to abstract the differences between different transaction managers and unify the operations on them.
+ * The operations supported here generally require direct field access or reflections on the transaction manager object,
+ * which is necessary for certain operations like setting the producer ID, epoch, or transaction ID.
+ *
+ * For regular transaction operations like beginTransaction, commitTransaction, and abortTransaction, they are not included here
+ * because they should be directly accessible via public APIs of the backend producer implementation.
+ *
+ * Each backend PubSub implementation should provide a TransactionManagerOperator implementation to support the operations,
+ * and register it in the TXN_MANAGER_CLASSNAME_TO_OPERATOR map.
+ */
 public class TransactionManagerUtils {
 
     private static final Map<String, TransactionManagerOperator> TXN_MANAGER_CLASSNAME_TO_OPERATOR = new HashMap<>();
@@ -21,37 +31,83 @@ public class TransactionManagerUtils {
         });
     }
 
+    /**
+     * Get the epoch of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @return the epoch of the transaction manager
+     */
     public static short getEpoch(Object transactionManager) {
         return getOrCreateTransactionManagerOperator(transactionManager).getEpoch(transactionManager);
     }
 
+    /**
+     * Get the producer ID of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @return the producer ID of the transaction manager
+     */
     public static long getProducerId(Object transactionManager) {
         return getOrCreateTransactionManagerOperator(transactionManager).getProducerId(transactionManager);
     }
 
+    /**
+     * Get the transaction ID of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @return the transaction ID of the transaction manager
+     */
     public static String getTransactionId(Object transactionManager) {
         return getOrCreateTransactionManagerOperator(transactionManager).getTransactionId(transactionManager);
     }
 
+    /**
+     * Set the epoch of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @param epoch the epoch to set
+     */
     public static void setEpoch(Object transactionManager, short epoch) {
         getOrCreateTransactionManagerOperator(transactionManager).setEpoch(transactionManager, epoch);
     }
 
+    /**
+     * Set the producer ID of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @param producerId the producer ID to set
+     */
     public static void setProducerId(Object transactionManager, long producerId) {
         getOrCreateTransactionManagerOperator(transactionManager).setProducerId(transactionManager, producerId);
     }
 
+    /**
+     * Set the transaction ID of the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @param transactionalId the transaction ID to set
+     */
     public static void setTransactionId(Object transactionManager, String transactionalId) {
         getOrCreateTransactionManagerOperator(transactionManager).setTransactionId(transactionManager, transactionalId);
     }
 
+    /**
+     * Enqueue in-flight transactions in the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @return a future that completes when the in-flight transactions are enqueued
+     */
     public static Future<Boolean> enqueueInFlightTransactions(Object transactionManager) {
         return getOrCreateTransactionManagerOperator(transactionManager).enqueueInFlightTransactions(transactionManager);
     }
 
+    /**
+     * Resume the transaction in the transaction manager.
+     *
+     * @param transactionManager the transaction manager object
+     * @param transactionalProperties the transactional properties
+     */
     public static void resumeTransaction(Object transactionManager, PscProducerTransactionalProperties transactionalProperties) {
         getOrCreateTransactionManagerOperator(transactionManager).resumeTransaction(transactionManager, transactionalProperties);
     }
-
-
 }

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/kafka/KafkaTransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/kafka/KafkaTransactionManagerOperator.java
@@ -1,7 +1,8 @@
-package com.pinterest.psc.producer.transaction;
+package com.pinterest.psc.producer.transaction.kafka;
 
 import com.pinterest.psc.common.PscCommon;
 import com.pinterest.psc.producer.PscProducerTransactionalProperties;
+import com.pinterest.psc.producer.transaction.TransactionManagerOperator;
 import org.apache.kafka.clients.producer.internals.TransactionManager;
 import org.apache.kafka.clients.producer.internals.TransactionalRequestResult;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;

--- a/psc/src/main/java/com/pinterest/psc/producer/transaction/kafka/KafkaTransactionManagerOperator.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/transaction/kafka/KafkaTransactionManagerOperator.java
@@ -5,6 +5,8 @@ import com.pinterest.psc.producer.PscProducerTransactionalProperties;
 import com.pinterest.psc.producer.transaction.TransactionManagerOperator;
 import org.apache.kafka.clients.producer.internals.TransactionManager;
 import org.apache.kafka.clients.producer.internals.TransactionalRequestResult;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 
 import java.lang.reflect.Constructor;
@@ -233,6 +235,21 @@ public class KafkaTransactionManagerOperator implements TransactionManagerOperat
 
         transitionTransactionManagerStateTo(transactionManager, "IN_TRANSACTION");
         PscCommon.setField(transactionManager, "transactionStarted", true);
+    }
+
+    /**
+     * Returns the transaction coordinator id of the transaction manager.
+     *
+     * @param transactionManager the transaction manager
+     * @return the transaction coordinator id
+     */
+    @Override
+    public int getTransactionCoordinatorId(Object transactionManager) {
+        Node coordinatorNode = (Node) PscCommon.invoke(transactionManager, "coordinator", FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+        if (coordinatorNode == null) {
+            throw new IllegalStateException("Transaction coordinator node is null");
+        }
+        return coordinatorNode.id();
     }
 
     /**

--- a/psc/src/test/java/com/pinterest/psc/producer/transaction/TestTransactionManagerUtils.java
+++ b/psc/src/test/java/com/pinterest/psc/producer/transaction/TestTransactionManagerUtils.java
@@ -1,0 +1,31 @@
+package com.pinterest.psc.producer.transaction;
+
+import org.apache.kafka.clients.producer.internals.TransactionManager;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestTransactionManagerUtils {
+
+    @Test
+    void testKafkaTransactionManagerOperator() {
+        // create a Kafka TransactionManager just for testing
+        TransactionManager transactionManager = new TransactionManager(new LogContext(), null, 10000, 100L, null, false);
+
+        long id = TransactionManagerUtils.getProducerId(transactionManager);
+        short epoch = TransactionManagerUtils.getEpoch(transactionManager);
+        String transactionId = TransactionManagerUtils.getTransactionId(transactionManager);
+        assertEquals(-1, id);   // uninitialized
+        assertEquals(-1, epoch);   // uninitialized
+        assertNull(transactionId);   // uninitialized
+
+        TransactionManagerUtils.setProducerId(transactionManager, 100L);
+        TransactionManagerUtils.setEpoch(transactionManager, (short) 1);
+        TransactionManagerUtils.setTransactionId(transactionManager, "transaction-id");
+        assertEquals(100L, TransactionManagerUtils.getProducerId(transactionManager));
+        assertEquals(1, TransactionManagerUtils.getEpoch(transactionManager));
+        assertEquals("transaction-id", TransactionManagerUtils.getTransactionId(transactionManager));
+    }
+}


### PR DESCRIPTION
1. Create a new utility class `TransactionManagerUtils` which centralizes and abstracts direct field access and reflections logic for Kafka's TransactionManager so that PSC's references can be backend-agnostic.

2. `PscProducer.send()` will throw an exception if the following condition is true: The user is attempting to send a message via an already transactional `PscProducer`, and if sending the message will result in the creation of an additional backendProducer when one already exists. If the producer is non-transactional at the time of `send()`, there is no enforcement.

See javadocs for more details.