### PR TITLE
Add 'corretto' distribution to maven central publish script

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
+          distribution: 'corretto'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
Distribution parameter is required for v4 action to publish to maven central.