### PR TITLE
Add another producer auto resolution scenario

### DIFF
--- a/psc/src/main/java/com/pinterest/psc/common/kafka/KafkaErrors.java
+++ b/psc/src/main/java/com/pinterest/psc/common/kafka/KafkaErrors.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidOffsetException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
+import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.SslAuthenticationException;
@@ -243,6 +244,14 @@ public class KafkaErrors {
                     // NotLeaderForPartitionException
                     .put(
                             NotLeaderForPartitionException.class,
+                            new LinkedHashMap<String, PscErrorHandler.ProducerAction>(1) {{
+                                put("", new PscErrorHandler.ProducerAction(PscErrorHandler.ActionType.RESET_THEN_THROW, ProducerException.class));
+                            }}
+                    )
+
+                    // NotLeaderOrFollowerException
+                    .put(
+                            NotLeaderOrFollowerException.class,
                             new LinkedHashMap<String, PscErrorHandler.ProducerAction>(1) {{
                                 put("", new PscErrorHandler.ProducerAction(PscErrorHandler.ActionType.RESET_THEN_THROW, ProducerException.class));
                             }}


### PR DESCRIPTION
This is a new exception since version 2.6 of Apache Kafka that PSC can auto resolve by resetting the Kafka producer.
```
Caused by: apache.kafka.common.errors.NotLeaderOrFollowerException: For requests intended only for the leader, this error indicates that the broker is not the current leader. For requests intended for any replica, this error indicates that the broker is not a replica of the topic partition.
```