### PR TITLE
Override consumer class used by PscKafkaConsumer

### DIFF
--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <kafka.version>3.4.0</kafka.version>
         <memq.version>0.2.21</memq.version>
+        <ts-consumer.version>1.0.0</ts-consumer.version>
     </properties>
 
     <dependencies>
@@ -31,6 +32,25 @@
                 <exclusion>
                     <groupId>slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.pinterest.kafka.tieredstorage</groupId>
+            <artifactId>ts-consumer</artifactId>
+            <version>${ts-consumer.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -97,12 +117,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.13.52</version>
+            <version>2.17.273</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.13.52</version>
+            <version>2.30.31</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -52,6 +52,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <kafka.version>3.4.0</kafka.version>
         <memq.version>0.2.21</memq.version>
-        <ts-consumer.version>1.0.0</ts-consumer.version>
+<!--        <ts-consumer.version>1.0.0</ts-consumer.version>-->
     </properties>
 
     <dependencies>
@@ -35,29 +35,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.pinterest.kafka.tieredstorage</groupId>
-            <artifactId>ts-consumer</artifactId>
-            <version>${ts-consumer.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>log4j-over-slf4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.ben-manes.caffeine</groupId>
-                    <artifactId>caffeine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+<!--        Commenting out ts-consumer dependency for now due to Java version compatibility issues, this dependency-->
+<!--        will need to be added by the application if ts-consumer is needed.-->
+<!--        <dependency>-->
+<!--            <groupId>com.pinterest.kafka.tieredstorage</groupId>-->
+<!--            <artifactId>ts-consumer</artifactId>-->
+<!--            <version>${ts-consumer.version}</version>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>log4j</groupId>-->
+<!--                    <artifactId>log4j</artifactId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>slf4j-log4j12</artifactId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>log4j-over-slf4j</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>

--- a/psc/src/main/java/com/pinterest/psc/consumer/kafka/PscKafkaConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/kafka/PscKafkaConsumer.java
@@ -2,7 +2,6 @@ package com.pinterest.psc.consumer.kafka;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import com.pinterest.kafka.tieredstorage.consumer.TieredStorageConsumer;
 import com.pinterest.psc.common.BaseTopicUri;
 import com.pinterest.psc.common.MessageId;
 import com.pinterest.psc.common.PscCommon;
@@ -110,7 +109,7 @@ public class PscKafkaConsumer<K, V> extends PscBackendConsumer<K, V> {
     /**
      * Initializes the Kafka consumer.
      */
-    protected void initializeKafkaConsumer() {
+    private void initializeKafkaConsumer() {
         String
             kafkaConsumerClassName =
             pscConfigurationInternal.getConfiguration()
@@ -645,8 +644,10 @@ public class PscKafkaConsumer<K, V> extends PscBackendConsumer<K, V> {
         // alternate reflection-based approach using a one-time call - performs ~ 20x faster
         SubscriptionState subscriptions;
         if (pscConfigurationInternal.getConfiguration().getString(PSC_CONSUMER_KAFKA_CONSUMER_CLASS)
-            != null && kafkaConsumer instanceof TieredStorageConsumer) {
-            // Retrieve subscriptions from underlying KafkaConsumer if using TieredStorageConsumer
+            != null) {
+            // Retrieve subscriptions from underlying KafkaConsumer.
+            // NOTE: if custom consumer class does not contain an underlying KafkaConsumer "kafkaConsumer" field, this call
+            // will fail with a RuntimeException.
             subscriptions =
                 (SubscriptionState) PscCommon.getField(
                     PscCommon.getField(kafkaConsumer, "kafkaConsumer"), "subscriptions");


### PR DESCRIPTION
Users can now define the consumer class via the `psc.consumer.kafka.consumer.class` configuration. If a custom class is not specified or if there's a problem initializing the consumer with the custom class, it defaults to using KafkaConsumer.