### PR TITLE
Remove redundant map check in kafka producer

### DIFF
--- a/psc/src/main/java/com/pinterest/psc/producer/kafka/PscKafkaProducer.java
+++ b/psc/src/main/java/com/pinterest/psc/producer/kafka/PscKafkaProducer.java
@@ -148,7 +148,7 @@ public class PscKafkaProducer<K, V> extends PscBackendProducer<K, V> {
     private boolean updateOrGetStatus(KafkaProducer<byte[], byte[]> kafkaProducer, Boolean isActive) {
         synchronized (kafkaProducer) {
             if (isActive == null) {
-                return allProducers.containsKey(kafkaProducer) && allProducers.get(kafkaProducer);
+                return Boolean.TRUE.equals(allProducers.get(kafkaProducer));
             } else {
                 allProducers.put(kafkaProducer, isActive.booleanValue());
                 return false; // no-op


### PR DESCRIPTION
parent send() method is very high throughput. Our flamegraphs show most CPU is spent in the ConcurrentHashMap checking. 

To validate that the ConcurrentHashMap is the high overhead component, remove a redundant map access. We should see high-throughput applications have much better performance when they are bottlenecked on PSC Producer. 