### PR TITLE
Bump version to 3.3.3-SNAPSHOT & Improve EC2 metadata fetching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.psc</groupId>
     <artifactId>psc-java-oss</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>psc-java-oss</name>
     <description>PubSub Client (PSC)</description>

--- a/psc-common/pom.xml
+++ b/psc-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-examples</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3-SNAPSHOT</version>
     <name>psc-examples</name>
 
     <properties>

--- a/psc-flink-logging/pom.xml
+++ b/psc-flink-logging/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-flink-logging</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/psc-flink/pom.xml
+++ b/psc-flink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pinterest.psc</groupId>
         <artifactId>psc-java-oss</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>psc-flink</artifactId>

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-logging/pom.xml
+++ b/psc-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>3.3.2</version>
+        <version>3.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
+++ b/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
@@ -84,7 +84,7 @@ public class Ec2EnvironmentProvider extends EnvironmentProvider {
                 return ec2MetadataFetcher.fetch();
             } catch (SdkClientException e) {
                 attempts++;
-                LOGGER.error("Failed to fetch {} from EC2 metadata with on attempt {}: {}",
+                LOGGER.error("Failed to fetch {} from EC2 metadata on attempt {}: {}",
                     propertyName,
                     attempts, e);
                 if (attempts >= MAX_FETCH_RETRIES) {

--- a/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
+++ b/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
@@ -1,56 +1,57 @@
 package com.pinterest.psc.environment;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.pinterest.psc.logging.PscLogger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 public class Ec2EnvironmentProvider extends EnvironmentProvider {
+
+    private static final PscLogger LOGGER = PscLogger.getLogger(
+        Ec2EnvironmentProvider.class);
     private static final String PROJECT_URI = "PROJECT_URI";
     private static final String PROJECT = "PROJECT";
     private static final String DEPLOYMENT_STAGE = "DEPLOYMENT_STAGE";
+    private static final int MAX_FETCH_RETRIES = 3;
 
     @Override
     public String getInstanceId() {
-        try {
-            return EC2MetadataUtils.getInstanceId();
-        } catch (SdkClientException e) {
-            return Environment.INFO_NOT_AVAILABLE;
+        if (environment.getInstanceId().equals(Environment.INFO_NOT_AVAILABLE)) {
+            environment.setInstanceId(fetchEC2MetadataWithRetries(EC2MetadataUtils::getInstanceId, "instanceId"));
         }
+        return environment.getInstanceId();
     }
 
     @Override
     public String getInstanceType() {
-        try {
-            return EC2MetadataUtils.getInstanceType();
-        } catch (SdkClientException e) {
-            return Environment.INFO_NOT_AVAILABLE;
+        if (environment.getInstanceType().equals(Environment.INFO_NOT_AVAILABLE)) {
+            environment.setInstanceType(fetchEC2MetadataWithRetries(EC2MetadataUtils::getInstanceType, "instanceType"));
         }
+        return environment.getInstanceType();
     }
 
     @Override
     public String getIpAddress() {
-        try {
-            return EC2MetadataUtils.getPrivateIpAddress();
-        } catch (SdkClientException e) {
-            return Environment.INFO_NOT_AVAILABLE;
+        if (environment.getIpAddress().equals(Environment.INFO_NOT_AVAILABLE)) {
+            environment.setIpAddress(fetchEC2MetadataWithRetries(EC2MetadataUtils::getPrivateIpAddress, "ipAddress"));
         }
+        return environment.getIpAddress();
     }
 
     @Override
     public String getLocality() {
-        try {
-            return EC2MetadataUtils.getAvailabilityZone();
-        } catch (SdkClientException e) {
-            return Environment.INFO_NOT_AVAILABLE;
+        if (environment.getLocality().equals(Environment.INFO_NOT_AVAILABLE)) {
+            environment.setLocality(fetchEC2MetadataWithRetries(EC2MetadataUtils::getAvailabilityZone, "locality"));
         }
+        return environment.getLocality();
     }
 
     @Override
     public String getRegion() {
-        try {
-            return EC2MetadataUtils.getEC2InstanceRegion();
-        } catch (SdkClientException e) {
-            return Environment.INFO_NOT_AVAILABLE;
+        if (environment.getRegion().equals(Environment.INFO_NOT_AVAILABLE)) {
+            environment.setRegion(fetchEC2MetadataWithRetries(EC2MetadataUtils::getEC2InstanceRegion, "region"));
         }
+        return environment.getRegion();
     }
 
     @Override
@@ -66,5 +67,56 @@ public class Ec2EnvironmentProvider extends EnvironmentProvider {
     @Override
     public String getProject() {
         return System.getenv(PROJECT);
+    }
+
+    /**
+     * Fetches EC2 metadata with retries and exponential backoff.
+     *
+     * @param ec2MetadataFetcher the function to fetch EC2 metadata
+     * @param propertyName       the name of the property being fetched, used for logging
+     * @return the fetched metadata or a default value if it fails
+     */
+    @VisibleForTesting
+    public String fetchEC2MetadataWithRetries(EC2MetadataFetcher ec2MetadataFetcher,
+        String propertyName) {
+        int attempts = 0;
+        long backoff = 500;
+
+        while (attempts < MAX_FETCH_RETRIES) {
+            try {
+                return ec2MetadataFetcher.fetch();
+            } catch (SdkClientException e) {
+                attempts++;
+                LOGGER.error("Failed to fetch {} from EC2 metadata with on attempt {}: {}",
+                    propertyName,
+                    attempts, e);
+                if (attempts >= MAX_FETCH_RETRIES) {
+                    break;
+                }
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    LOGGER.error(
+                        "Interrupted while waiting to retry fetching {} from EC2 metadata: {}",
+                        propertyName, ie.getMessage());
+                    return Environment.INFO_NOT_AVAILABLE;
+                }
+                backoff *= 2;
+            }
+        }
+        LOGGER.error(
+            "Failed to fetch {} from EC2 metadata after {} attempts, returning default value.",
+            propertyName, MAX_FETCH_RETRIES);
+        return Environment.INFO_NOT_AVAILABLE;
+    }
+
+    /**
+     * Functional interface for fetching EC2 metadata.
+     * This allows for different metadata fetch methods to be passed in.
+     */
+    @FunctionalInterface
+    public interface EC2MetadataFetcher {
+
+        String fetch() throws SdkClientException;
     }
 }

--- a/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
+++ b/psc/src/main/java/com/pinterest/psc/environment/Ec2EnvironmentProvider.java
@@ -14,44 +14,41 @@ public class Ec2EnvironmentProvider extends EnvironmentProvider {
     private static final String DEPLOYMENT_STAGE = "DEPLOYMENT_STAGE";
     private static final int MAX_FETCH_RETRIES = 3;
 
+    // Static variables to cache EC2 metadata
+    private static String instanceId;
+    private static String instanceType;
+    private static String ipAddress;
+    private static String locality;
+    private static String region;
+
     @Override
     public String getInstanceId() {
-        if (environment.getInstanceId().equals(Environment.INFO_NOT_AVAILABLE)) {
-            environment.setInstanceId(fetchEC2MetadataWithRetries(EC2MetadataUtils::getInstanceId, "instanceId"));
-        }
-        return environment.getInstanceId();
+        return instanceId == null ? instanceId = fetchEC2MetadataWithRetries(
+            EC2MetadataUtils::getInstanceId, "instanceId") : instanceId;
     }
 
     @Override
     public String getInstanceType() {
-        if (environment.getInstanceType().equals(Environment.INFO_NOT_AVAILABLE)) {
-            environment.setInstanceType(fetchEC2MetadataWithRetries(EC2MetadataUtils::getInstanceType, "instanceType"));
-        }
-        return environment.getInstanceType();
+        return instanceType == null ? instanceType = fetchEC2MetadataWithRetries(
+            EC2MetadataUtils::getInstanceType, "instanceType") : instanceType;
     }
 
     @Override
     public String getIpAddress() {
-        if (environment.getIpAddress().equals(Environment.INFO_NOT_AVAILABLE)) {
-            environment.setIpAddress(fetchEC2MetadataWithRetries(EC2MetadataUtils::getPrivateIpAddress, "ipAddress"));
-        }
-        return environment.getIpAddress();
+        return ipAddress == null ? ipAddress = fetchEC2MetadataWithRetries(
+            EC2MetadataUtils::getPrivateIpAddress, "ipAddress") : ipAddress;
     }
 
     @Override
     public String getLocality() {
-        if (environment.getLocality().equals(Environment.INFO_NOT_AVAILABLE)) {
-            environment.setLocality(fetchEC2MetadataWithRetries(EC2MetadataUtils::getAvailabilityZone, "locality"));
-        }
-        return environment.getLocality();
+        return locality == null ? locality = fetchEC2MetadataWithRetries(
+            EC2MetadataUtils::getAvailabilityZone, "locality") : locality;
     }
 
     @Override
     public String getRegion() {
-        if (environment.getRegion().equals(Environment.INFO_NOT_AVAILABLE)) {
-            environment.setRegion(fetchEC2MetadataWithRetries(EC2MetadataUtils::getEC2InstanceRegion, "region"));
-        }
-        return environment.getRegion();
+        return region == null ? region = fetchEC2MetadataWithRetries(
+            EC2MetadataUtils::getEC2InstanceRegion, "region") : region;
     }
 
     @Override
@@ -98,7 +95,7 @@ public class Ec2EnvironmentProvider extends EnvironmentProvider {
                 } catch (InterruptedException ie) {
                     LOGGER.error(
                         "Interrupted while waiting to retry fetching {} from EC2 metadata: {}",
-                        propertyName, ie.getMessage());
+                        propertyName, ie);
                     return Environment.INFO_NOT_AVAILABLE;
                 }
                 backoff *= 2;

--- a/psc/src/test/java/com/pinterest/psc/environment/Ec2EnvironmentProviderTest.java
+++ b/psc/src/test/java/com/pinterest/psc/environment/Ec2EnvironmentProviderTest.java
@@ -1,0 +1,36 @@
+package com.pinterest.psc.environment;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Ec2EnvironmentProviderTest {
+
+    @Test
+    public void testCachedMetadata() {
+        Ec2EnvironmentProvider ec2EnvironmentProvider = new Ec2EnvironmentProvider();
+        Environment env = ec2EnvironmentProvider.getEnvironment();
+        env.setInstanceId("i-test");
+        env.setInstanceType("instancetype1");
+        env.setIpAddress("0.0.0.0");
+        env.setLocality("us-region-1a");
+        env.setRegion("us-region-1");
+
+        // These shouldn't invoke calls to EC2MetadataUtils now that the fields are set
+        assertEquals("i-test", ec2EnvironmentProvider.getInstanceId());
+        assertEquals("instancetype1", ec2EnvironmentProvider.getInstanceType());
+        assertEquals("0.0.0.0", ec2EnvironmentProvider.getIpAddress());
+        assertEquals("us-region-1a", ec2EnvironmentProvider.getLocality());
+        assertEquals("us-region-1", ec2EnvironmentProvider.getRegion());
+    }
+
+    @Test
+    public void testRetryLogic() {
+        Ec2EnvironmentProvider ec2EnvironmentProvider = new Ec2EnvironmentProvider();
+        assertEquals(Environment.INFO_NOT_AVAILABLE, ec2EnvironmentProvider.fetchEC2MetadataWithRetries(() -> {
+            throw SdkClientException.create("Simulated failure");
+        }, "testField"));
+        assertEquals("us-region-1", ec2EnvironmentProvider.fetchEC2MetadataWithRetries(() -> "us-region-1", "region"));
+    }
+}


### PR DESCRIPTION
Improve Ec2EnvironmentProvider by caching the metadata in static variables in order to avoid making calls to EC2 metadata server every time an Environment object is created.