### PR TITLE
Fix container manifest to allow integration tests on Mac M3 chipset

### DIFF
--- a/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
@@ -28,5 +28,5 @@ public class DockerImageVersions {
 
     public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.4.4";
 
-    public static final String ZOOKEEPER = "zookeeper:3.4.14";
+    public static final String ZOOKEEPER = "confluentinc/cp-zookeeper:7.4.4";
 }

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
@@ -507,7 +507,9 @@ public class PscTestEnvironmentWithKafkaAsPubSubImpl extends PscTestEnvironmentW
         return new GenericContainer<>(DockerImageName.parse(DockerImageVersions.ZOOKEEPER))
                 .withNetwork(network)
                 .withNetworkAliases(ZOOKEEPER_HOSTNAME)
-                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT));
+                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT))
+                .withEnv("ZOOKEEPER_TICK_TIME", "2000")
+                .withEnv("ZOOKEEPER_SERVER_ID", "1");
     }
 
     private KafkaContainer createKafkaContainer(


### PR DESCRIPTION
Diff to fix the `psc-flink` integration tests on Mac M3 chip:
`yipan@yipan-J3VYNYG psc % git diff
diff --git a/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java b/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
index 250706a..599fcf7 100644
--- a/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
@@ -28,5 +28,5 @@ public class DockerImageVersions {
 
     public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.4.4";
 
-    public static final String ZOOKEEPER = "zookeeper:3.4.14";
+    public static final String ZOOKEEPER = "confluentinc/cp-zookeeper:7.4.4";
 }
diff --git a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
index 3f1c2ea..cb287ed 100644
--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
@@ -507,7 +507,9 @@ public class PscTestEnvironmentWithKafkaAsPubSubImpl extends PscTestEnvironmentW
         return new GenericContainer<>(DockerImageName.parse(DockerImageVersions.ZOOKEEPER))
                 .withNetwork(network)
                 .withNetworkAliases(ZOOKEEPER_HOSTNAME)
-                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT));
+                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT))
+                .withEnv("ZOOKEEPER_TICK_TIME", "2000")
+                .withEnv("ZOOKEEPER_SERVER_ID", "1");
     }
 
     private KafkaContainer createKafkaContainer(`