### PR TITLE
Cherry-pick AUTO_GEN_UUID, sticky UID prefix commits; Bump version to 4.1.3-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>psc-java-oss</artifactId>
     <description>PubSub Client (PSC)</description>
     <url>https://github.com/pinterest/psc</url>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.3-RC1</version>
     <packaging>pom</packaging>
     <name>psc-java-oss</name>
     <modules>

--- a/psc-common/pom.xml
+++ b/psc-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-examples</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.3-RC1</version>
     <name>psc-examples</name>
 
     <properties>

--- a/psc-flink-logging/pom.xml
+++ b/psc-flink-logging/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>psc-flink-logging</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.3-RC1</version>
 
     <dependencies>
         <dependency>

--- a/psc-flink/pom.xml
+++ b/psc-flink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pinterest.psc</groupId>
         <artifactId>psc-java-oss</artifactId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>psc-flink</artifactId>

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptions.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptions.java
@@ -18,6 +18,7 @@
 
 package com.pinterest.flink.streaming.connectors.psc.table;
 
+import com.pinterest.psc.config.PscConfiguration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -129,11 +130,47 @@ public class PscConnectorOptions {
                             "Optional topic pattern from which the table is read for source. Either 'topic' or 'topic-pattern' must be set.");
 
     public static final ConfigOption<String> PROPS_GROUP_ID =
-            ConfigOptions.key("properties.group.id")
+            ConfigOptions.key("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID)
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Required consumer group in PSC consumer, no need for PSC producer");
+                            Description.builder()
+                                    .text("Required consumer group in PSC consumer, no need for PSC producer. ")
+                                    .text("Set to 'AUTO_GEN_UUID' to generate a group id w/ dynamic UUID suffix automatically as an ephemeral group.")
+                                    .build());
+
+
+    public static final ConfigOption<String> PROPS_PRODUCER_CLIENT_ID =
+            ConfigOptions.key("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID)
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("Mandatory client ID for PSC producer. ")
+                                    .text("Use 'AUTO_GEN_UUID' to automatically generate a producer id w/ dynamic UUID suffix.")
+                                    .build());
+
+    public static final ConfigOption<String> PROPS_CLIENT_ID_PREFIX =
+            ConfigOptions.key("properties.client.id.prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                .text("Mandatory client ID prefix for generating client IDs. ")
+                                .text("Always required for PSC table sources to ensure unique client identification. ")
+                                .text("Used as prefix for auto-generated client IDs when consumer client.id is not provided or when using AUTO_GEN_UUID for any ID options.")
+                                .build());
+
+    public static final ConfigOption<String> PROPS_CLIENT_ID =
+            ConfigOptions.key("properties." + PscConfiguration.PSC_CONSUMER_CLIENT_ID)
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("Optional client ID for PSC consumer.")
+                                    .text("Use as alias for 'properties.client.id.prefix' for backward compatibility.")
+                                    .build());
+
 
     // --------------------------------------------------------------------------------------------
     // Scan specific options

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptions.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptions.java
@@ -176,6 +176,15 @@ public class PscConnectorOptions {
     // Scan specific options
     // --------------------------------------------------------------------------------------------
 
+    public static final ConfigOption<String> SOURCE_UID_PREFIX =
+            ConfigOptions.key("source.uid-prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional prefix used to derive a stable UID for the PSC source operator. "
+                                    + "When set, the connector will assign a deterministic UID to the source transformation "
+                                    + "based on this prefix to ensure checkpoint state compatibility across DAG changes.");
+
     public static final ConfigOption<ScanStartupMode> SCAN_STARTUP_MODE =
             ConfigOptions.key("scan.startup.mode")
                     .enumType(ScanStartupMode.class)

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicSource.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicSource.java
@@ -166,6 +166,9 @@ public class PscDynamicSource
 
     protected final String tableIdentifier;
 
+    /** Optional user-provided UID prefix for stabilizing operator UIDs across DAG changes. */
+    protected final @Nullable String sourceUidPrefix;
+
     public PscDynamicSource(
             DataType physicalDataType,
             @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
@@ -183,7 +186,8 @@ public class PscDynamicSource
             Map<PscTopicUriPartition, Long> specificBoundedOffsets,
             long boundedTimestampMillis,
             boolean upsertMode,
-            String tableIdentifier) {
+            String tableIdentifier,
+            @Nullable String sourceUidPrefix) {
         // Format attributes
         this.physicalDataType =
                 Preconditions.checkNotNull(
@@ -223,6 +227,50 @@ public class PscDynamicSource
         this.boundedTimestampMillis = boundedTimestampMillis;
         this.upsertMode = upsertMode;
         this.tableIdentifier = tableIdentifier;
+        this.sourceUidPrefix = sourceUidPrefix;
+    }
+
+    /**
+     * Backward-compatible constructor without UID prefix. Delegates to the full constructor with a
+     * null {@code sourceUidPrefix}.
+     */
+    public PscDynamicSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<PscTopicUriPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis,
+            BoundedMode boundedMode,
+            Map<PscTopicUriPartition, Long> specificBoundedOffsets,
+            long boundedTimestampMillis,
+            boolean upsertMode,
+            String tableIdentifier) {
+        this(
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                boundedMode,
+                specificBoundedOffsets,
+                boundedTimestampMillis,
+                upsertMode,
+                tableIdentifier,
+                null);
     }
 
     @Override
@@ -254,6 +302,14 @@ public class PscDynamicSource
                 DataStreamSource<RowData> sourceStream =
                         execEnv.fromSource(
                                 pscSource, watermarkStrategy, "PscSource-" + tableIdentifier);
+                // Prefer explicit user-provided UID prefix if present; otherwise rely on provider context.
+                if (sourceUidPrefix != null) {
+                    final String trimmedPrefix = sourceUidPrefix.trim();
+                    if (!trimmedPrefix.isEmpty()) {
+                        sourceStream.uid(trimmedPrefix + ":" + PSC_TRANSFORMATION + ":" + tableIdentifier);
+                        return sourceStream;
+                    }
+                }
                 providerContext.generateUid(PSC_TRANSFORMATION).ifPresent(sourceStream::uid);
                 return sourceStream;
             }
@@ -339,7 +395,8 @@ public class PscDynamicSource
                         specificBoundedOffsets,
                         boundedTimestampMillis,
                         upsertMode,
-                        tableIdentifier);
+                        tableIdentifier,
+                        sourceUidPrefix);
         copy.producedDataType = producedDataType;
         copy.metadataKeys = metadataKeys;
         copy.watermarkStrategy = watermarkStrategy;

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactory.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactory.java
@@ -91,6 +91,7 @@ import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOpt
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.getSourceTopicUriPattern;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.getSourceTopicUris;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.getStartupOptions;
+import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateDeliveryGuarantee;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateTableSinkOptions;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateTableSourceOptions;
 
@@ -245,9 +246,10 @@ public class PscDynamicTableFactory
         final ReadableConfig tableOptions = helper.getOptions();
 
         final DeliveryGuarantee deliveryGuarantee = validateDeprecatedSemantic(tableOptions);
+        
         validateTableSinkOptions(tableOptions);
 
-        PscConnectorOptionsUtil.validateDeliveryGuarantee(tableOptions);
+        validateDeliveryGuarantee(tableOptions);
 
         validatePKConstraints(
                 context.getObjectIdentifier(),

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactory.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactory.java
@@ -70,6 +70,7 @@ import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOpt
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_BOUNDED_MODE;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_BOUNDED_SPECIFIC_OFFSETS;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_BOUNDED_TIMESTAMP_MILLIS;
+import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SOURCE_UID_PREFIX;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_STARTUP_MODE;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_STARTUP_SPECIFIC_OFFSETS;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
@@ -148,6 +149,7 @@ public class PscDynamicTableFactory
         options.add(SCAN_BOUNDED_MODE);
         options.add(SCAN_BOUNDED_SPECIFIC_OFFSETS);
         options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
+        options.add(SOURCE_UID_PREFIX);
         return options;
     }
 
@@ -226,7 +228,8 @@ public class PscDynamicTableFactory
                 boundedOptions.boundedMode,
                 boundedOptions.specificOffsets,
                 boundedOptions.boundedTimestampMillis,
-                context.getObjectIdentifier().asSummaryString());
+                context.getObjectIdentifier().asSummaryString(),
+                tableOptions.getOptional(SOURCE_UID_PREFIX).orElse(null));
     }
 
     @Override
@@ -391,7 +394,8 @@ public class PscDynamicTableFactory
             BoundedMode boundedMode,
             Map<PscTopicUriPartition, Long> specificEndOffsets,
             long endTimestampMillis,
-            String tableIdentifier) {
+            String tableIdentifier,
+            @Nullable String sourceUidPrefix) {
         return new PscDynamicSource(
                 physicalDataType,
                 keyDecodingFormat,
@@ -409,7 +413,8 @@ public class PscDynamicTableFactory
                 specificEndOffsets,
                 endTimestampMillis,
                 false,
-                tableIdentifier);
+                tableIdentifier,
+                sourceUidPrefix);
     }
 
     protected PscDynamicSink creatPscTableSink(

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscDynamicTableFactory.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscDynamicTableFactory.java
@@ -77,6 +77,8 @@ import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOpt
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.getSourceTopicUriPattern;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.getSourceTopicUris;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateScanBoundedMode;
+import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateConsumerClientOptions;
+import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.validateProducerClientOptions;
 
 /** Upsert-Psc factory. */
 public class UpsertPscDynamicTableFactory
@@ -246,6 +248,7 @@ public class UpsertPscDynamicTableFactory
             int[] primaryKeyIndexes) {
         validateTopic(tableOptions);
         validateScanBoundedMode(tableOptions);
+        validateConsumerClientOptions(tableOptions);
         validateFormat(keyFormat, valueFormat, tableOptions);
         validatePKConstraints(primaryKeyIndexes);
     }
@@ -257,6 +260,7 @@ public class UpsertPscDynamicTableFactory
             int[] primaryKeyIndexes) {
         validateTopic(tableOptions);
         validateFormat(keyFormat, valueFormat, tableOptions);
+        validateProducerClientOptions(tableOptions);
         validatePKConstraints(primaryKeyIndexes);
         validateSinkBufferFlush(tableOptions);
     }

--- a/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscDynamicTableFactory.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscDynamicTableFactory.java
@@ -64,6 +64,7 @@ import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOpt
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SINK_PARALLELISM;
+import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.SOURCE_UID_PREFIX;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.TOPIC_URI;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.TRANSACTIONAL_ID_PREFIX;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptions.VALUE_FIELDS_INCLUDE;
@@ -113,6 +114,7 @@ public class UpsertPscDynamicTableFactory
         options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
         options.add(DELIVERY_GUARANTEE);
         options.add(TRANSACTIONAL_ID_PREFIX);
+        options.add(SOURCE_UID_PREFIX);
         return options;
     }
 
@@ -165,7 +167,8 @@ public class UpsertPscDynamicTableFactory
                 boundedOptions.specificOffsets,
                 boundedOptions.boundedTimestampMillis,
                 true,
-                context.getObjectIdentifier().asSummaryString());
+                context.getObjectIdentifier().asSummaryString(),
+                tableOptions.getOptional(SOURCE_UID_PREFIX).orElse(null));
     }
 
     @Override

--- a/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/connector/psc/testutils/DockerImageVersions.java
@@ -28,5 +28,5 @@ public class DockerImageVersions {
 
     public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.4.4";
 
-    public static final String ZOOKEEPER = "zookeeper:3.4.14";
+    public static final String ZOOKEEPER = "confluentinc/cp-zookeeper:7.4.4";
 }

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/PscTestEnvironmentWithKafkaAsPubSubImpl.java
@@ -507,7 +507,9 @@ public class PscTestEnvironmentWithKafkaAsPubSubImpl extends PscTestEnvironmentW
         return new GenericContainer<>(DockerImageName.parse(DockerImageVersions.ZOOKEEPER))
                 .withNetwork(network)
                 .withNetworkAliases(ZOOKEEPER_HOSTNAME)
-                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT));
+                .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT))
+                .withEnv("ZOOKEEPER_TICK_TIME", "2000")
+                .withEnv("ZOOKEEPER_SERVER_ID", "1");
     }
 
     private KafkaContainer createKafkaContainer(

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptionsTest.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptionsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinterest.flink.streaming.connectors.psc.table;
+
+import com.pinterest.psc.config.PscConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link PscConnectorOptions} ConfigOptions definitions. */
+public class PscConnectorOptionsTest {
+
+    @Test
+    public void testConfigOptionsDefaultValues() {
+        // Test default values for ConfigOptions
+        // All ID options now have no default value and support AUTO_GEN_UUID when explicitly set
+        assertNull(
+                "Group ID should have no default value (required)",
+                PscConnectorOptions.PROPS_GROUP_ID.defaultValue());
+        // Consumer client ID option has been removed - it's now auto-generated when missing
+        assertNull(
+                "Producer client ID should have no default value (optional)",
+                PscConnectorOptions.PROPS_PRODUCER_CLIENT_ID.defaultValue());
+        assertNull(
+                "Client ID prefix should have no default value (required when using AUTO_GEN_UUID)",
+                PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.defaultValue());
+    }
+
+    @Test
+    public void testConfigOptionsKeys() {
+        // Test that ConfigOptions have correct keys
+        assertEquals("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptions.PROPS_GROUP_ID.key());
+        // Consumer client ID option removed - now auto-generated when missing
+        assertEquals("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID, PscConnectorOptions.PROPS_PRODUCER_CLIENT_ID.key());
+    }
+
+    @Test
+    public void testGroupIdMandatoryConfiguration() {
+        // Test that group_id has no default value (making it mandatory)
+        assertNull("Group ID should have no default value", PscConnectorOptions.PROPS_GROUP_ID.defaultValue());
+        
+        // Verify description exists (content checking removed due to Flink API changes)
+        assertNotNull("Group ID should have description", PscConnectorOptions.PROPS_GROUP_ID.description());
+    }
+
+    @Test
+    public void testIdOptionsConfiguration() {
+        // Test ID options configuration behavior - all should be optional with no default values
+        // Consumer client ID option removed - now auto-generated when missing
+        assertNull("Producer client ID should have no default value",
+                PscConnectorOptions.PROPS_PRODUCER_CLIENT_ID.defaultValue());
+        assertNull("Consumer group ID should have no default value",
+                PscConnectorOptions.PROPS_GROUP_ID.defaultValue());
+        assertNull("Client ID prefix should have no default value",
+                PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.defaultValue());
+    }
+
+    @Test
+    public void testConfigOptionDescriptions() {
+        // Test that ConfigOptions have meaningful descriptions
+        assertNotNull("Group ID should have description", PscConnectorOptions.PROPS_GROUP_ID.description());
+        // Consumer client ID option removed - description no longer exists
+        assertNotNull("Producer Client ID should have description", PscConnectorOptions.PROPS_PRODUCER_CLIENT_ID.description());
+
+        // Note: Specific description content checks removed due to Flink API toString() behavior changes
+        // The descriptions are properly defined using Description.builder() and contain the expected content
+    }
+}

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptionsUtilTest.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscConnectorOptionsUtilTest.java
@@ -26,9 +26,18 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 
+import com.pinterest.psc.config.PscConfiguration;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.createKeyFormatProjection;
 import static com.pinterest.flink.streaming.connectors.psc.table.PscConnectorOptionsUtil.createValueFormatProjection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
@@ -147,6 +156,629 @@ public class PscConnectorOptionsUtilTest {
                             equalTo(
                                     "A key prefix is not allowed when option 'value.fields-include' "
                                             + "is set to 'ALL'. Set it to 'EXCEPT_KEY' instead to avoid field overlaps.")));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // AUTO_GEN_UUID Functionality Tests
+    // --------------------------------------------------------------------------------------------
+
+    @Test
+    public void testAutoGenUuidConstant() {
+        // Test that AUTO_GEN_UUID constant is correctly defined
+        assertEquals("AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+    }
+
+    @Test
+    public void testGetPscPropertiesWithAutoGenUuidGroupId() {
+        // Test AUTO_GEN_UUID replacement for group_id with client.id.prefix
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        tableOptions.put("properties.client.id.prefix", "test-app");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        assertNotNull("Group ID should not be null", groupId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", "AUTO_GEN_UUID", groupId);
+        assertTrue("Group ID should start with client.id.prefix", groupId.startsWith("test-app-"));
+
+        // Verify the suffix after prefix is a valid UUID
+        String uuidPart = groupId.substring("test-app-".length());
+        try {
+            UUID.fromString(uuidPart);
+        } catch (IllegalArgumentException e) {
+            fail("Generated group ID suffix should be a valid UUID: " + uuidPart);
+        }
+    }
+
+    @Test
+    public void testGetPscPropertiesWithoutConsumerClientId() {
+        // Test that missing consumer client ID is not set (handled by PscTopicUriPartitionSplitReader)
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties.client.id.prefix", "test-client");
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "test-group");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        // Consumer client ID should not be present - it's handled elsewhere
+        String clientId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_CLIENT_ID);
+        assertEquals("Consumer client ID should not be set in properties", null, clientId);
+        // Other properties should be present
+        assertEquals("test-group", pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID));
+    }
+
+    @Test
+    public void testGetPscPropertiesWithAutoGenProducerClientId() {
+        // Test AUTO_GEN_UUID replacement for producer client_id
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties.client.id.prefix", "test-producer");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String producerClientId = pscProperties.getProperty(PscConfiguration.PSC_PRODUCER_CLIENT_ID);
+        assertNotNull("Producer client ID should not be null", producerClientId);
+        assertNotEquals("Producer client ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, producerClientId);
+        assertTrue("Producer client ID should start with prefix", producerClientId.startsWith("test-producer-"));
+
+        // Verify the suffix is a valid UUID
+        String uuidPart = producerClientId.substring("test-producer-".length());
+        try {
+            UUID.fromString(uuidPart);
+        } catch (IllegalArgumentException e) {
+            fail("Generated producer client ID suffix should be a valid UUID: " + uuidPart);
+        }
+    }
+
+    @Test
+    public void testGetPscPropertiesWithMultipleAutoGen() {
+        // Test AUTO_GEN_UUID replacement for multiple properties (group ID + producer ID)
+        // Consumer client ID is handled by PscTopicUriPartitionSplitReader
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties.client.id.prefix", "multi-test");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        String clientId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_CLIENT_ID);
+        String producerClientId = pscProperties.getProperty(PscConfiguration.PSC_PRODUCER_CLIENT_ID);
+
+        // Group ID and Producer ID should be valid prefixed UUIDs
+        assertNotNull("Group ID should not be null", groupId);
+        assertEquals("Consumer client ID should not be set", null, clientId);  // Handled elsewhere
+        assertNotNull("Producer Client ID should not be null", producerClientId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, groupId);
+        assertNotEquals("Producer Client ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, producerClientId);
+
+        // Group ID and Producer Client ID should start with prefix
+        assertTrue("Group ID should start with prefix", groupId.startsWith("multi-test-"));
+        assertTrue("Producer Client ID should start with prefix", producerClientId.startsWith("multi-test-"));
+
+        // Group ID and producer client ID should be different UUIDs
+        assertNotEquals("Group ID and producer client ID should be different", groupId, producerClientId);
+
+        // Verify suffix parts are valid UUIDs
+        try {
+            String groupUuidPart = groupId.substring("multi-test-".length());
+            String producerUuidPart = producerClientId.substring("multi-test-".length());
+            UUID.fromString(groupUuidPart);
+            UUID.fromString(producerUuidPart);
+        } catch (IllegalArgumentException e) {
+            fail("All generated ID suffixes should be valid UUIDs");
+        }
+    }
+
+    @Test
+    public void testGetPscPropertiesWithNonAutoGenValues() {
+        // Test that non-AUTO_GEN values are preserved (consumer client ID handled elsewhere)
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "my-group");
+        tableOptions.put("properties.client.id.prefix", "non-auto");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        assertEquals("my-group", pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID));
+        // Consumer client ID should not be set (handled by PscTopicUriPartitionSplitReader)
+        String clientId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_CLIENT_ID);
+        assertEquals("Consumer client ID should not be set", null, clientId);
+    }
+
+    @Test
+    public void testGetPscPropertiesWithMixedValues() {
+        // Test mixing AUTO_GEN_UUID and regular values (consumer client ID handled elsewhere)
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties.some.other.property", "some-value");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "mixed-test");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        assertNotNull("Group ID should not be null", groupId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, groupId);
+        assertTrue("Group ID should start with prefix", groupId.startsWith("mixed-test-"));
+
+        // Verify UUID suffix
+        String uuidPart = groupId.substring("mixed-test-".length());
+        try {
+            UUID.fromString(uuidPart);
+        } catch (IllegalArgumentException e) {
+            fail("Generated group ID suffix should be a valid UUID");
+        }
+
+        // Consumer client ID should not be set in properties (handled by PscTopicUriPartitionSplitReader)
+        String clientId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_CLIENT_ID);
+        assertEquals("Consumer client ID should not be set", null, clientId);
+        assertEquals("some-value", pscProperties.getProperty("some.other.property"));
+    }
+
+    @Test
+    public void testGetPscPropertiesWithOtherProperties() {
+        // Test that other PSC properties are preserved alongside AUTO_GEN_UUID
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties.bootstrap.servers", "localhost:9092");
+        tableOptions.put("properties.session.timeout.ms", "30000");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "other-test");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        assertNotNull("Group ID should not be null", groupId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, groupId);
+        assertTrue("Group ID should start with prefix", groupId.startsWith("other-test-"));
+        assertEquals("localhost:9092", pscProperties.getProperty("bootstrap.servers"));
+        assertEquals("30000", pscProperties.getProperty("session.timeout.ms"));
+    }
+
+    @Test
+    public void testGetPscPropertiesWithEmptyOptions() {
+        // Test with empty options
+        Map<String, String> tableOptions = new HashMap<>();
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        assertTrue("Properties should be empty", pscProperties.isEmpty());
+    }
+
+    @Test
+    public void testGetPscPropertiesWithNoPropertiesPrefix() {
+        // Test with options that don't have properties prefix
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("format", "json");
+        tableOptions.put("topic", "my-topic");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        assertTrue("Properties should be empty when no properties prefix", pscProperties.isEmpty());
+    }
+
+    @Test
+    public void testAutoGenGeneratesUniqueUUIDs() {
+        // Test that each call to getPscProperties with AUTO_GEN_UUID generates unique UUIDs
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "unique-test");
+
+        Properties properties1 = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+        Properties properties2 = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId1 = properties1.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        String groupId2 = properties2.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+
+        assertNotNull("Group ID 1 should not be null", groupId1);
+        assertNotNull("Group ID 2 should not be null", groupId2);
+        assertNotEquals("Each call should generate unique UUIDs", groupId1, groupId2);
+        assertTrue("Group ID 1 should start with prefix", groupId1.startsWith("unique-test-"));
+        assertTrue("Group ID 2 should start with prefix", groupId2.startsWith("unique-test-"));
+    }
+
+    @Test
+    public void testGetPscPropertiesPreservesOtherProperties() {
+        // Test that AUTO_GEN_UUID processing doesn't affect other property handling
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put("properties.max.poll.records", "1000");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "preserve-test");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        assertNotNull("Group ID should not be null", groupId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE, groupId);
+        assertTrue("Group ID should start with prefix", groupId.startsWith("preserve-test-"));
+        assertEquals("1000", pscProperties.getProperty("max.poll.records"));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // AUTO_GEN Validation Tests
+    // --------------------------------------------------------------------------------------------
+
+    @Test
+    public void testValidateAutoGenUuidOptionsWithAllowedKeys() {
+        // Test that the function does not throw for allowed keys with valid client.id.prefix
+        // Note: Consumer client ID is no longer allowed with AUTO_GEN_UUID - it's auto-generated when missing
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+        try {
+            // Only group ID and producer client ID are allowed with AUTO_GEN_UUID
+            PscConnectorOptionsUtil.validateAutoGenUuidOptions(PscConfiguration.PSC_CONSUMER_GROUP_ID, tableOptions);
+            PscConnectorOptionsUtil.validateAutoGenUuidOptions(PscConfiguration.PSC_PRODUCER_CLIENT_ID, tableOptions);
+            // If we get here, all validations passed
+        } catch (ValidationException e) {
+            fail("Validation should not fail for allowed keys: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidateAutoGenUuidOptionsWithNonAllowedKeys() {
+        // Test that the function throws ValidationException for non-allowed keys
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+        String[] nonAllowedKeys = {
+            "bootstrap.servers",
+            "session.timeout.ms",
+            "max.poll.records",
+            "random.property",
+            PscConfiguration.PSC_CONSUMER_CLIENT_ID,  // Consumer client ID no longer allowed with AUTO_GEN_UUID
+            ""
+        };
+        for (String key : nonAllowedKeys) {
+            try {
+                PscConnectorOptionsUtil.validateAutoGenUuidOptions(key, tableOptions);
+                fail("Should have thrown ValidationException for key: " + key);
+            } catch (ValidationException e) {
+                // Expected - verify error message contains the key and mentions allowed keys
+                String message = e.getMessage();
+                assertTrue("Error message should mention the invalid key", message.contains(key));
+                assertTrue("Error message should mention AUTO_GEN_UUID", message.contains("AUTO_GEN_UUID"));
+                assertTrue("Error message should list allowed keys", message.contains(PscConfiguration.PSC_CONSUMER_GROUP_ID));
+            }
+        }
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateAutoGenUuidOptionsWithNull() {
+        // Test that null throws ValidationException
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+        PscConnectorOptionsUtil.validateAutoGenUuidOptions(null, tableOptions);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testGetPscPropertiesWithAutoGenOnNonAllowedKey() {
+        // Test that using AUTO_GEN_UUID with non-allowed keys throws ValidationException
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties.bootstrap.servers", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test");
+
+        PscConnectorOptionsUtil.getPscProperties(tableOptions);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testGetPscPropertiesWithAutoGenOnAnotherNonAllowedKey() {
+        // Test with another non-allowed key
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties.session.timeout.ms", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test");
+
+        PscConnectorOptionsUtil.getPscProperties(tableOptions);
+    }
+
+    @Test
+    public void testGetPscPropertiesValidationMessage() {
+        // Test that the validation error message is informative
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties.invalid.key", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test");
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Should have thrown ValidationException");
+        } catch (ValidationException e) {
+            String message = e.getMessage();
+            assertTrue("Error message should mention the invalid key", message.contains("invalid.key"));
+            assertTrue("Error message should mention AUTO_GEN_UUID", message.contains("AUTO_GEN_UUID"));
+            assertTrue("Error message should list allowed keys", message.contains(PscConfiguration.PSC_CONSUMER_GROUP_ID));
+            assertTrue("Error message should list allowed keys", message.contains(PscConfiguration.PSC_PRODUCER_CLIENT_ID));
+        }
+    }
+
+    @Test
+    public void testGetPscPropertiesWithMixedValidAndInvalidAutoGen() {
+        // Test mixing allowed AUTO_GEN_UUID with non-allowed AUTO_GEN_UUID
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);  // This should work
+        tableOptions.put("properties.invalid.key", PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);  // This should fail
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "mixed");
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Should have thrown ValidationException for invalid.key");
+        } catch (ValidationException e) {
+            assertTrue("Error should be about the invalid key", e.getMessage().contains("invalid.key"));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Validation and Parsing Tests
+    // --------------------------------------------------------------------------------------------
+
+    @Test
+    public void testParseSpecificOffsetsStillWorks() {
+        // Test that existing functionality still works
+        String specificOffsets = "partition:0,offset:42;partition:1,offset:300";
+
+        Map<Integer, Long> offsetMap = PscConnectorOptionsUtil.parseSpecificOffsets(specificOffsets, "test-key");
+
+        assertEquals(2, offsetMap.size());
+        assertEquals(Long.valueOf(42), offsetMap.get(0));
+        assertEquals(Long.valueOf(300), offsetMap.get(1));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testParseSpecificOffsetsValidation() {
+        // Test that validation still works
+        String invalidOffsets = "invalid-format";
+
+        PscConnectorOptionsUtil.parseSpecificOffsets(invalidOffsets, "test-key");
+    }
+
+    @Test
+    public void testAutoGenUuidRequiresClientIdPrefix() {
+        // Test that AUTO_GEN_UUID requires client.id.prefix
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        // Intentionally not setting client.id.prefix
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Should have thrown ValidationException for missing client.id.prefix");
+        } catch (ValidationException e) {
+            String message = e.getMessage();
+            assertTrue("Error message should mention client.id.prefix requirement",
+                    message.contains("properties.client.id.prefix") && message.contains("must be provided"));
+        }
+    }
+
+    @Test
+    public void testAutoGenUuidWithEmptyClientIdPrefix() {
+        // Test that AUTO_GEN_UUID requires non-empty client.id.prefix
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "");
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Should have thrown ValidationException for empty client.id.prefix");
+        } catch (ValidationException e) {
+            String message = e.getMessage();
+            assertTrue("Error message should mention client.id.prefix requirement",
+                    message.contains("properties.client.id.prefix") && message.contains("must be non-empty"));
+        }
+    }
+
+    @Test
+    public void testAutoGenUuidWithWhitespaceOnlyClientIdPrefix() {
+        // Test that AUTO_GEN_UUID requires non-empty client.id.prefix after trimming
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "   ");  // Only whitespace
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Should have thrown ValidationException for whitespace-only client.id.prefix");
+        } catch (ValidationException e) {
+            String message = e.getMessage();
+            assertTrue("Error message should mention trimming whitespace",
+                    message.contains("after trimming whitespace"));
+        }
+    }
+
+    @Test
+    public void testAutoGenUuidWithTrimmableClientIdPrefix() {
+        // Test that AUTO_GEN_UUID properly trims client.id.prefix whitespace
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "  my-app  ");  // Leading and trailing whitespace
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        assertNotNull("Group ID should not be null", groupId);
+        assertNotEquals("Group ID should not be AUTO_GEN_UUID", "AUTO_GEN_UUID", groupId);
+        assertTrue("Group ID should start with trimmed prefix", groupId.startsWith("my-app-"));
+        assertFalse("Group ID should not have leading whitespace", groupId.startsWith(" "));
+        assertFalse("Group ID should not have trailing whitespace in prefix", groupId.contains("  -"));
+
+        // Verify the UUID part after the prefix is valid
+        String uuidPart = groupId.substring("my-app-".length());
+        try {
+            UUID.fromString(uuidPart);
+        } catch (IllegalArgumentException e) {
+            fail("Generated group ID suffix should be a valid UUID: " + uuidPart);
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // New Validation Methods Tests
+    // --------------------------------------------------------------------------------------------
+
+    @Test
+    public void testValidateConsumerClientOptionsSuccess() {
+        // Test that validateConsumerClientOptions passes with valid configuration
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "test-group");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+        Configuration config = Configuration.fromMap(tableOptions);
+        try {
+            PscConnectorOptionsUtil.validateConsumerClientOptions(config);
+            // Should not throw exception
+        } catch (ValidationException e) {
+            fail("Should not fail with valid consumer client options: " + e.getMessage());
+        }
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateConsumerClientOptionsWithMissingGroupId() {
+        // Test that validateConsumerClientOptions fails when group ID is missing
+        Map<String, String> tableOptions = new HashMap<>();
+        // Missing group ID
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+        Configuration config = Configuration.fromMap(tableOptions);
+        PscConnectorOptionsUtil.validateConsumerClientOptions(config);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateConsumerClientOptionsWithMissingClientIdPrefix() {
+        // Test that validateConsumerClientOptions fails when client.id.prefix is missing
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "test-group");
+        // Missing client.id.prefix
+        Configuration config = Configuration.fromMap(tableOptions);
+        PscConnectorOptionsUtil.validateConsumerClientOptions(config);
+    }
+
+    @Test
+    public void testValidateProducerClientOptionsSuccess() {
+        // Test that validateProducerClientOptions passes with valid configuration
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID, "test-producer");
+        Configuration config = Configuration.fromMap(tableOptions);
+        try {
+            PscConnectorOptionsUtil.validateProducerClientOptions(config);
+            // Should not throw exception
+        } catch (ValidationException e) {
+            fail("Should not fail with valid producer client options: " + e.getMessage());
+        }
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateProducerClientOptionsWithMissingProducerId() {
+        // Test that validateProducerClientOptions fails when producer client ID is missing
+        Map<String, String> tableOptions = new HashMap<>();
+        // Missing producer client ID
+        Configuration config = Configuration.fromMap(tableOptions);
+        PscConnectorOptionsUtil.validateProducerClientOptions(config);
+    }
+
+    @Test
+    public void testValidateProducerClientOptionsWithAutoGenUuid() {
+        // Test that validateProducerClientOptions works with AUTO_GEN_UUID
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_PRODUCER_CLIENT_ID, PscConnectorOptionsUtil.AUTO_GEN_UUID_VALUE);
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-producer");
+        Configuration config = Configuration.fromMap(tableOptions);
+        try {
+            PscConnectorOptionsUtil.validateProducerClientOptions(config);
+            // Should not throw exception
+        } catch (ValidationException e) {
+            fail("Should not fail with AUTO_GEN_UUID producer client options: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetPscPropertiesDoesNotSetConsumerClientId() {
+        // Test that consumer client ID is not set in properties (handled by PscTopicUriPartitionSplitReader)
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "test-group");
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "test-prefix");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+
+        String clientId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_CLIENT_ID);
+        assertEquals("Consumer client ID should not be set in properties", null, clientId);
+        // Other properties should be present
+        assertEquals("test-group", pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID));
+    }
+
+    @Test
+    public void testClientIdPrefixAlias() {
+        // Test that properties.psc.consumer.client.id works as an alias for properties.client.id.prefix
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        // Use alias instead of primary key
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_CLIENT_ID, "test-alias-prefix");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+
+        // Verify AUTO_GEN_UUID was processed with the alias prefix
+        assertNotNull("Generated group ID should not be null", groupId);
+        assertNotEquals("Generated group ID should not equal AUTO_GEN_UUID", "AUTO_GEN_UUID", groupId);
+        assertTrue("Generated group ID should start with alias prefix", groupId.startsWith("test-alias-prefix-"));
+
+        // Verify the UUID part is valid
+        String uuidPart = groupId.substring("test-alias-prefix-".length());
+        try {
+            UUID.fromString(uuidPart);
+            // If no exception is thrown, the UUID is valid
+        } catch (IllegalArgumentException e) {
+            fail("Generated group ID suffix should be a valid UUID: " + uuidPart);
+        }
+    }
+
+    @Test
+    public void testClientIdPrefixPrimaryTakesPrecedence() {
+        // Test that properties.client.id.prefix takes precedence over the alias when both are provided
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        // Provide both primary key and alias
+        tableOptions.put(PscConnectorOptions.PROPS_CLIENT_ID_PREFIX.key(), "primary-prefix");
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_CLIENT_ID, "alias-prefix");
+
+        Properties pscProperties = PscConnectorOptionsUtil.getPscProperties(tableOptions);
+        String groupId = pscProperties.getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+
+        // Verify the primary key prefix was used, not the alias
+        assertNotNull("Generated group ID should not be null", groupId);
+        assertTrue("Generated group ID should start with primary prefix", groupId.startsWith("primary-prefix-"));
+        assertFalse("Generated group ID should not start with alias prefix", groupId.startsWith("alias-prefix-"));
+    }
+
+    @Test
+    public void testClientIdPrefixAliasValidationError() {
+        // Test that validation error mentions both primary key and alias when neither is provided
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        // Don't provide either primary key or alias
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Expected ValidationException to be thrown");
+        } catch (ValidationException e) {
+            // Verify the error message mentions both the primary key and alias
+            String message = e.getMessage();
+            assertTrue("Error message should mention primary key",
+                       message.contains("properties.client.id.prefix"));
+            assertTrue("Error message should mention alias",
+                       message.contains("properties.psc.consumer.client.id"));
+        }
+    }
+
+    @Test
+    public void testClientIdPrefixAliasEmptyValidationError() {
+        // Test that validation error occurs when alias is provided but empty
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_GROUP_ID, "AUTO_GEN_UUID");
+        // Provide empty alias
+        tableOptions.put("properties." + PscConfiguration.PSC_CONSUMER_CLIENT_ID, "   ");
+
+        try {
+            PscConnectorOptionsUtil.getPscProperties(tableOptions);
+            fail("Expected ValidationException to be thrown");
+        } catch (ValidationException e) {
+            // Verify the error message mentions non-empty requirement for both primary key and alias
+            String message = e.getMessage();
+            assertTrue("Error message should mention non-empty requirement",
+                       message.contains("must be non-empty"));
+            assertTrue("Error message should mention primary key",
+                       message.contains("properties.client.id.prefix"));
+            assertTrue("Error message should mention alias",
+                       message.contains("properties.psc.consumer.client.id"));
         }
     }
 

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactoryUidOptionTest.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscDynamicTableFactoryUidOptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinterest.flink.streaming.connectors.psc.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class PscDynamicTableFactoryUidOptionTest {
+
+    @Test
+    public void testPscFactoryOptionalOptionsContainSourceUidPrefix() {
+        PscDynamicTableFactory factory = new PscDynamicTableFactory();
+        Set<ConfigOption<?>> opts = factory.optionalOptions();
+        Assert.assertTrue(
+            opts.stream().anyMatch(opt -> "source.uid-prefix".equals(opt.key())));
+    }
+
+    @Test
+    public void testUpsertFactoryOptionalOptionsContainSourceUidPrefix() {
+        UpsertPscDynamicTableFactory factory = new UpsertPscDynamicTableFactory();
+        Set<ConfigOption<?>> opts = factory.optionalOptions();
+        Assert.assertTrue(
+            opts.stream().anyMatch(opt -> "source.uid-prefix".equals(opt.key())));
+    }
+}

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscTableITCase.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/PscTableITCase.java
@@ -1190,6 +1190,780 @@ public class PscTableITCase extends PscTableTestBase {
                 .satisfies(FlinkAssertions.anyCauseMatches(NoOffsetForPartitionException.class));
     }
 
+    @Test
+    public void testAutoGenUuidSourceTableWithClientIdAndGroupId() throws Exception {
+        final String topic = "tstopic_autogen_source_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE autogen_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'integration-test-source',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Create a regular sink table for validation
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE validation_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'validation-sink-client',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Insert test data
+        String insertData =
+                "INSERT INTO validation_sink\n"
+                        + "VALUES\n"
+                        + " (1, 'Alice', TIMESTAMP '2023-01-01 10:00:00'),\n"
+                        + " (2, 'Bob', TIMESTAMP '2023-01-01 11:00:00'),\n"
+                        + " (3, 'Charlie', TIMESTAMP '2023-01-01 12:00:00')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read from source with AUTO_GEN_UUID properties
+        String query = "SELECT id, name FROM autogen_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("AutoGenUuid_Source_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully read (proves AUTO_GEN_UUID worked)
+        // Order is not guaranteed in streaming, so we check the count and presence of data
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testAutoGenUuidSinkTableWithProducerId() throws Exception {
+        final String topic = "tstopic_autogen_sink_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create sink table with AUTO_GEN_UUID for producer client ID
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE autogen_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  amount DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'integration-test-sink',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Create a regular source table for validation
+        String groupId = getStandardProps().getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE validation_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  amount DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'validation-source-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        groupId,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Insert data using sink with AUTO_GEN_UUID producer client ID
+        String insertData =
+                "INSERT INTO autogen_sink\n"
+                        + "VALUES\n"
+                        + " (10, 'Product A', 99.99),\n"
+                        + " (20, 'Product B', 149.50),\n"
+                        + " (30, 'Product C', 299.00)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify sink worked (proves AUTO_GEN_UUID worked)
+        String query = "SELECT id, name, CAST(amount AS DECIMAL(10, 2)) FROM validation_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("AutoGenUuid_Sink_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully written and read back (proves AUTO_GEN_UUID worked)
+        // Order is not guaranteed in streaming, so we check the count and presence of data
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testMinimumConsumerConfigurationSourceTable() throws Exception {
+        final String topic = "tstopic_min_consumer_source_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create source table with minimum required consumer configuration
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE min_consumer_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'min-consumer-client-id',\n"
+                                + "  'properties.psc.consumer.group.id' = 'min-consumer-group-id',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Create sink table to write test data
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE data_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'data-sink-producer-client',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Insert test data
+        String insertData =
+                "INSERT INTO data_sink\n"
+                        + "VALUES\n"
+                        + " (1, 'MinConfig1', TIMESTAMP '2023-01-01 10:00:00'),\n"
+                        + " (2, 'MinConfig2', TIMESTAMP '2023-01-01 11:00:00'),\n"
+                        + " (3, 'MinConfig3', TIMESTAMP '2023-01-01 12:00:00')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read from source with minimum consumer configuration
+        String query = "SELECT id, name FROM min_consumer_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("MinConsumerConfig_Source_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully read with minimum consumer configuration
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testMinimumProducerConfigurationSinkTable() throws Exception {
+        final String topic = "tstopic_min_producer_sink_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create sink table with minimum required producer configuration
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE min_producer_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'min-producer-client-id',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Create source table to read back data
+        String groupId = getStandardProps().getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE validation_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'validation-source-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        groupId,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Insert data using sink with minimum producer configuration
+        String insertData =
+                "INSERT INTO min_producer_sink\n"
+                        + "VALUES\n"
+                        + " (100, 'MinProd1', 10.5),\n"
+                        + " (200, 'MinProd2', 20.75),\n"
+                        + " (300, 'MinProd3', 30.25)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify sink worked with minimum producer configuration
+        String query = "SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM validation_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("MinProducerConfig_Sink_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully written with minimum producer configuration
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testMinimumConfigurationWithAutoGenUuidSourceTable() throws Exception {
+        final String topic = "tstopic_min_autogen_source_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create source table with minimum required configuration using AUTO_GEN_UUID
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE min_autogen_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'min-config',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Create sink table to write test data
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE data_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  ts TIMESTAMP(3)\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'data-sink-producer-client',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Insert test data
+        String insertData =
+                "INSERT INTO data_sink\n"
+                        + "VALUES\n"
+                        + " (1, 'MinAutoGen1', TIMESTAMP '2023-01-01 10:00:00'),\n"
+                        + " (2, 'MinAutoGen2', TIMESTAMP '2023-01-01 11:00:00'),\n"
+                        + " (3, 'MinAutoGen3', TIMESTAMP '2023-01-01 12:00:00')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read from source with minimum configuration using AUTO_GEN_UUID
+        String query = "SELECT id, name FROM min_autogen_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("MinAutoGenConfig_Source_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully read with minimum AUTO_GEN_UUID configuration
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testMinimumConfigurationWithAutoGenUuidSinkTable() throws Exception {
+        final String topic = "tstopic_min_autogen_sink_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create sink table with minimum required configuration using AUTO_GEN_UUID
+        final String createSinkTable =
+                String.format(
+                        "CREATE TABLE min_autogen_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'min-sink-config',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSinkTable);
+
+        // Create source table to read back data
+        String groupId = getStandardProps().getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        final String createSourceTable =
+                String.format(
+                        "CREATE TABLE validation_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'validation-source-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        groupId,
+                        formatOptions());
+
+        tEnv.executeSql(createSourceTable);
+
+        // Insert data using sink with minimum AUTO_GEN_UUID configuration
+        String insertData =
+                "INSERT INTO min_autogen_sink\n"
+                        + "VALUES\n"
+                        + " (1000, 'MinAutoSink1', 100.5),\n"
+                        + " (2000, 'MinAutoSink2', 200.75),\n"
+                        + " (3000, 'MinAutoSink3', 300.25)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify sink worked with minimum AUTO_GEN_UUID configuration
+        String query = "SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM validation_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(3);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("MinAutoGenConfig_Sink_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully written with minimum AUTO_GEN_UUID configuration
+        assertThat(TestingSinkFunction.rows).hasSize(3);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCreateTableLikeLegacyBaseWithAutoGenUuidOverride() throws Exception {
+        final String topic = "tstopic_like_legacy_autogen_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create legacy base source table with traditional configuration (specific group id)
+        String baseGroupId = getStandardProps().getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        final String createBaseTable =
+                String.format(
+                        "CREATE TABLE legacy_base_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.client.id' = 'legacy-consumer-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        baseGroupId,
+                        formatOptions());
+
+        tEnv.executeSql(createBaseTable);
+
+        // Create derived table using CREATE TABLE ... LIKE with AUTO_GEN_UUID override
+        final String createDerivedTable =
+                "CREATE TABLE derived_autogen_source\n"
+                        + "WITH (\n"
+                        + "  'properties.client.id.prefix' = 'derived-autogen-client',\n"
+                        + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID'\n"
+                        + ") LIKE legacy_base_source";
+
+        tEnv.executeSql(createDerivedTable);
+
+        // Create sink to produce test data
+        final String createSink =
+                String.format(
+                        "CREATE TABLE test_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'test-sink-client',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSink);
+
+        // Insert test data
+        String insertData =
+                "INSERT INTO test_sink\n"
+                        + "VALUES\n"
+                        + " (1100, 'LikeLegacy1', 110.5),\n"
+                        + " (1200, 'LikeLegacy2', 120.75)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Verify derived table can read data with AUTO_GEN_UUID configuration
+        String query = "SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM derived_autogen_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(2);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("CreateTableLike_Legacy_AutoGen_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully read using derived table with AUTO_GEN_UUID
+        assertThat(TestingSinkFunction.rows).hasSize(2);
+        assertThat(TestingSinkFunction.rows).contains("+I(1100,LikeLegacy1,110.50)");
+        assertThat(TestingSinkFunction.rows).contains("+I(1200,LikeLegacy2,120.75)");
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCreateTableLikeAutoGenBaseWithSpecificGroupIdOverride() throws Exception {
+        final String topic = "tstopic_like_autogen_specific_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create base source table with AUTO_GEN_UUID configuration
+        final String createBaseTable =
+                String.format(
+                        "CREATE TABLE autogen_base_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'autogen-base-client',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createBaseTable);
+
+        // Create derived table using CREATE TABLE ... LIKE with specific user-defined group id
+        String specificGroupId = "derived-specific-group-" + UUID.randomUUID().toString().substring(0, 8);
+        final String createDerivedTable =
+                String.format(
+                        "CREATE TABLE derived_specific_source\n"
+                                + "WITH (\n"
+                                + "  'properties.client.id.prefix' = 'derived-specific-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s'\n"
+                                + ") LIKE autogen_base_source",
+                        specificGroupId);
+
+        tEnv.executeSql(createDerivedTable);
+
+        // Create sink to produce test data
+        final String createSink =
+                String.format(
+                        "CREATE TABLE test_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'test-sink-client',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  %s\n"
+                                + ")",
+                        PscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        formatOptions());
+
+        tEnv.executeSql(createSink);
+
+        // Insert test data
+        String insertData =
+                "INSERT INTO test_sink\n"
+                        + "VALUES\n"
+                        + " (1300, 'LikeSpecific1', 130.5),\n"
+                        + " (1400, 'LikeSpecific2', 140.75)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Verify derived table can read data with specific group id
+        String query = "SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM derived_specific_source";
+        DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
+        TestingSinkFunction sink = new TestingSinkFunction(2);
+        result.addSink(sink).setParallelism(1);
+
+        try {
+            env.execute("CreateTableLike_AutoGen_Specific_Test");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+
+        // Verify data was successfully read using derived table with specific group id
+        assertThat(TestingSinkFunction.rows).hasSize(2);
+        assertThat(TestingSinkFunction.rows).contains("+I(1300,LikeSpecific1,130.50)");
+        assertThat(TestingSinkFunction.rows).contains("+I(1400,LikeSpecific2,140.75)");
+
+        deleteTestTopic(topic);
+    }
+
     private List<String> appendNewData(
             String topic, String tableName, String groupId, int targetNum) throws Exception {
         waitUtil(

--- a/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscTableITCase.java
+++ b/psc-flink/src/test/java/com/pinterest/flink/streaming/connectors/psc/table/UpsertPscTableITCase.java
@@ -19,6 +19,7 @@
 package com.pinterest.flink.streaming.connectors.psc.table;
 
 import com.pinterest.flink.streaming.connectors.psc.PscTestEnvironmentWithKafkaAsPubSub;
+import com.pinterest.psc.config.PscConfiguration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
@@ -1183,5 +1184,500 @@ public class UpsertPscTableITCase extends PscTableTestBase {
                         7);
 
         assertThat(result).satisfies(matching(deepEqualTo(expected, true)));
+    }
+
+    @Test
+    public void testUpsertAutoGenUuidWithConsumerGroupAndProducerId() throws Exception {
+        final String topic = "tstopic_upsert_autogen_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create upsert table with AUTO_GEN_UUID for both consumer and producer client IDs
+        final String createUpsertTable =
+                String.format(
+                        "CREATE TABLE upsert_autogen_table (\n"
+                                + "  `id` INT,\n"
+                                + "  `name` STRING,\n"
+                                + "  `value` DOUBLE,\n"
+                                + "  PRIMARY KEY (`id`) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'upsert-psc',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'upsert-test',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createUpsertTable);
+
+        // Insert test data to verify the table works with AUTO_GEN_UUID
+        String insertData =
+                "INSERT INTO upsert_autogen_table VALUES\n"
+                        + " (1, 'Alice', 100.0),\n"
+                        + " (2, 'Bob', 200.0)";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify AUTO_GEN_UUID worked with upsert
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM upsert_autogen_table"), 2);
+
+        // Just verify we can read data successfully - this proves the AUTO_GEN_UUID configuration worked
+        assertThat(result).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testUpsertMinimumConfigurationWithExplicitIds() throws Exception {
+        final String topic = "tstopic_upsert_min_explicit_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create upsert table with minimum required explicit configuration
+        final String createUpsertTable =
+                String.format(
+                        "CREATE TABLE upsert_min_explicit_table (\n"
+                                + "  `id` INT,\n"
+                                + "  `name` STRING,\n"
+                                + "  `status` STRING,\n"
+                                + "  PRIMARY KEY (`id`) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'upsert-psc',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'min-upsert-group',\n"
+                                + "  'properties.psc.producer.client.id' = 'min-upsert-producer',\n"
+                                + "  'properties.client.id.prefix' = 'min-explicit',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createUpsertTable);
+
+        // Insert test data to verify the table works with minimum configuration
+        String insertData =
+                "INSERT INTO upsert_min_explicit_table VALUES\n"
+                        + " (10, 'User10', 'ACTIVE'),\n"
+                        + " (20, 'User20', 'INACTIVE')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify minimum configuration worked with upsert
+        // For upsert tables, we expect to see records in the changelog
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM upsert_min_explicit_table"), 2);
+
+        // Just verify we can read data successfully - this proves the AUTO_GEN_UUID configuration worked
+        assertThat(result).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testUpsertMinimumConfigurationWitMixedIds() throws Exception {
+        final String topic = "tstopic_upsert_min_mixed_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create upsert table with minimum required explicit configuration
+        final String createUpsertTable =
+                String.format(
+                        "CREATE TABLE upsert_min_mixed_table (\n"
+                                + "  `id` INT,\n"
+                                + "  `name` STRING,\n"
+                                + "  `status` STRING,\n"
+                                + "  PRIMARY KEY (`id`) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'upsert-psc',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.psc.producer.client.id' = 'min-upsert-producer',\n"
+                                + "  'properties.client.id.prefix' = 'min-mixed',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createUpsertTable);
+
+        // Insert test data to verify the table works with minimum configuration
+        String insertData =
+                "INSERT INTO upsert_min_mixed_table VALUES\n"
+                        + " (10, 'User10', 'ACTIVE'),\n"
+                        + " (20, 'User20', 'INACTIVE')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify minimum configuration worked with upsert
+        // For upsert tables, we expect to see records in the changelog
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM upsert_min_mixed_table"), 2);
+
+        // Just verify we can read data successfully - this proves the AUTO_GEN_UUID configuration worked
+        assertThat(result).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testUpsertMinimumConfigurationWitMixedProducerIds() throws Exception {
+        final String topic = "tstopic_upsert_mixed_producer_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create upsert table with minimum required explicit configuration
+        final String createUpsertTable =
+                String.format(
+                        "CREATE TABLE upsert_mixed_producer_table (\n"
+                                + "  `id` INT,\n"
+                                + "  `name` STRING,\n"
+                                + "  `status` STRING,\n"
+                                + "  PRIMARY KEY (`id`) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'upsert-psc',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'mixed-upsert-producer-group',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'mixed-producer',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createUpsertTable);
+
+        // Insert test data to verify the table works with minimum configuration
+        String insertData =
+                "INSERT INTO upsert_mixed_producer_table VALUES\n"
+                        + " (10, 'User10', 'ACTIVE'),\n"
+                        + " (20, 'User20', 'INACTIVE')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify minimum configuration worked with upsert
+        // For upsert tables, we expect to see records in the changelog
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM upsert_mixed_producer_table"), 2);
+
+        // Just verify we can read data successfully - this proves the AUTO_GEN_UUID configuration worked
+        assertThat(result).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testUpsertAutoGenUuidWithKeyValueFormats() throws Exception {
+        final String topic = "tstopic_upsert_keyvalue_autogen_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create upsert table with AUTO_GEN_UUID and key/value formats
+        final String createUpsertTable =
+                String.format(
+                        "CREATE TABLE upsert_keyvalue_autogen_table (\n"
+                                + "  `product_id` INT,\n"
+                                + "  `product_name` STRING,\n"
+                                + "  `price` DECIMAL(10,2),\n"
+                                + "  `category` STRING,\n"
+                                + "  PRIMARY KEY (`product_id`) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'upsert-psc',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'properties.client.id.prefix' = 'keyvalue-upsert',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s',\n"
+                                + "  'value.fields-include' = 'EXCEPT_KEY'\n"
+                                + ")",
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createUpsertTable);
+
+        // Insert test product data
+        String insertData =
+                "INSERT INTO upsert_keyvalue_autogen_table VALUES\n"
+                        + " (1001, 'Laptop', 999.99, 'Electronics'),\n"
+                        + " (1002, 'Mouse', 29.99, 'Electronics')";
+
+        tEnv.executeSql(insertData).await();
+
+        // Read back the data to verify key/value format with AUTO_GEN_UUID worked
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM upsert_keyvalue_autogen_table"), 2);
+
+        // Just verify we can read data successfully - this proves the key/value AUTO_GEN_UUID configuration worked
+        assertThat(result).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCreateTableLikeLegacyUpsertBaseWithAutoGenUuidOverride() throws Exception {
+        final String topic = "tstopic_upsert_like_legacy_autogen_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create legacy base upsert source table with traditional configuration (specific group id)
+        String baseGroupId = getStandardProps().getProperty(PscConfiguration.PSC_CONSUMER_GROUP_ID);
+        final String createBaseTable =
+                String.format(
+                        "CREATE TABLE legacy_upsert_base_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE,\n"
+                                + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.psc.consumer.client.id' = 'legacy-upsert-consumer-client',\n"
+                                + "  'properties.psc.consumer.group.id' = '%s',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        UpsertPscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        baseGroupId,
+                        format,
+                        format);
+
+        tEnv.executeSql(createBaseTable);
+
+        // Create derived upsert table using CREATE TABLE ... LIKE with AUTO_GEN_UUID override
+        final String createDerivedTable =
+                "CREATE TABLE derived_upsert_autogen_source\n"
+                        + "WITH (\n"
+                        + "  'properties.client.id.prefix' = 'derived-upsert-autogen-client',\n"
+                        + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID'\n"
+                        + ") LIKE legacy_upsert_base_source";
+
+        tEnv.executeSql(createDerivedTable);
+
+        // Create upsert sink to produce test data
+        final String createSink =
+                String.format(
+                        "CREATE TABLE test_upsert_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE,\n"
+                                + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'test-upsert-sink-client',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        UpsertPscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createSink);
+
+        // Insert test data (including updates to test upsert behavior)
+        String insertData =
+                "INSERT INTO test_upsert_sink\n"
+                        + "VALUES\n"
+                        + " (1100, 'UpsertLikeLegacy1', 110.5),\n"
+                        + " (1200, 'UpsertLikeLegacy2', 120.75),\n"
+                        + " (1100, 'UpsertLikeLegacy1Updated', 111.5)"; // Update first row
+
+        tEnv.executeSql(insertData).await();
+
+        // Verify derived upsert table can read data with AUTO_GEN_UUID configuration
+        // Using collectRows since this is an upsert table and we expect final state
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM derived_upsert_autogen_source"), 2);
+
+        // Verify upsert behavior: should have 2 final rows (data successfully read)
+        assertThat(result).hasSize(2);
+
+        // Convert to strings for easier assertion (format matches collectRows output)
+        List<String> resultStrings = result.stream().map(Object::toString).collect(Collectors.toList());
+        // Note: The actual data format from collectRows appears to be raw CSV values
+        // Just verify we can read the data successfully - this proves the CREATE TABLE ... LIKE functionality worked
+        assertThat(resultStrings).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCreateTableLikeAutoGenUpsertBaseWithSpecificGroupIdOverride() throws Exception {
+        final String topic = "tstopic_upsert_like_autogen_specific_" + format + "_" + UUID.randomUUID();
+        final String topicUri = PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX + topic;
+        createTestTopic(topic, 1, 1);
+
+        String bootstraps = getBootstrapServers();
+
+        // Create base upsert source table with AUTO_GEN_UUID configuration
+        final String createBaseTable =
+                String.format(
+                        "CREATE TABLE autogen_upsert_base_source (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE,\n"
+                                + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'autogen-upsert-base-client',\n"
+                                + "  'properties.psc.consumer.group.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        UpsertPscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createBaseTable);
+
+        // Create derived upsert table using CREATE TABLE ... LIKE with specific user-defined group id
+        String specificGroupId = "derived-upsert-specific-group-" + UUID.randomUUID().toString().substring(0, 8);
+        final String createDerivedTable =
+                String.format(
+                        "CREATE TABLE derived_upsert_specific_source\n"
+                                + "WITH (\n"
+                                + "  'properties.psc.consumer.group.id' = '%s'\n"
+                                + ") LIKE autogen_upsert_base_source",
+                        specificGroupId);
+
+        tEnv.executeSql(createDerivedTable);
+
+        // Create upsert sink to produce test data
+        final String createSink =
+                String.format(
+                        "CREATE TABLE test_upsert_sink (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + "  `value` DOUBLE,\n"
+                                + "  PRIMARY KEY (id) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic-uri' = '%s',\n"
+                                + "  'properties.psc.cluster.uri' = '%s',\n"
+                                + "  'properties.psc.discovery.topic.uri.prefixes' = '%s',\n"
+                                + "  'properties.psc.discovery.connection.urls' = '%s',\n"
+                                + "  'properties.psc.discovery.security.protocols' = 'plaintext',\n"
+                                + "  'properties.client.id.prefix' = 'test-upsert-sink-client',\n"
+                                + "  'properties.psc.producer.client.id' = 'AUTO_GEN_UUID',\n"
+                                + "  'key.format' = '%s',\n"
+                                + "  'value.format' = '%s'\n"
+                                + ")",
+                        UpsertPscDynamicTableFactory.IDENTIFIER,
+                        topicUri,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        PscTestEnvironmentWithKafkaAsPubSub.PSC_TEST_CLUSTER0_URI_PREFIX,
+                        bootstraps,
+                        format,
+                        format);
+
+        tEnv.executeSql(createSink);
+
+        // Insert test data (including updates to test upsert behavior)
+        String insertData =
+                "INSERT INTO test_upsert_sink\n"
+                        + "VALUES\n"
+                        + " (1300, 'UpsertLikeSpecific1', 130.5),\n"
+                        + " (1400, 'UpsertLikeSpecific2', 140.75),\n"
+                        + " (1300, 'UpsertLikeSpecific1Updated', 131.5)"; // Update first row
+
+        tEnv.executeSql(insertData).await();
+
+        // Verify derived upsert table can read data with specific group id
+        final List<Row> result = collectRows(tEnv.sqlQuery("SELECT id, name, CAST(`value` AS DECIMAL(10, 2)) FROM derived_upsert_specific_source"), 2);
+
+        // Verify upsert behavior: should have 2 final rows (data successfully read)
+        assertThat(result).hasSize(2);
+
+        // Convert to strings for easier assertion (format matches collectRows output)
+        List<String> resultStrings = result.stream().map(Object::toString).collect(Collectors.toList());
+        // Note: The actual data format from collectRows appears to be raw CSV values
+        // Just verify we can read the data successfully - this proves the CREATE TABLE ... LIKE functionality worked
+        assertThat(resultStrings).hasSize(2);
+
+        deleteTestTopic(topic);
+    }
+
+    private String formatOptions() {
+        return String.format("'format' = '%s'", format);
     }
 }

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc-logging/pom.xml
+++ b/psc-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>psc-java-oss</artifactId>
         <groupId>com.pinterest.psc</groupId>
-        <version>4.1.3-SNAPSHOT</version>
+        <version>4.1.3-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Cherry-picking latest commits from `main` to prepare for release testing.

Commits:
- 3d55da815fb726ea05b2cca7510b5e9e8d058138 (Allow integration tests on M3 chipset)
- 21c46dca39e6e1e9e2d6bc840e9a12bc6d1451a8 (AUTO_GEN_UUID feature)
- 0bc7256bed9f53da3d39732e1267cfe052574e06 (Sticky UID for table source operators)