### PR TITLE
Add Memq Metadata Client

### DIFF
--- a/psc-examples/pom.xml
+++ b/psc-examples/pom.xml
@@ -15,7 +15,7 @@
     <name>psc-examples</name>
 
     <properties>
-        <memq.version>0.2.21</memq.version>
+        <memq.version>1.0.2</memq.version>
     </properties>
 
     <dependencies>

--- a/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/MemqSourceReaderMetricsUtil.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/MemqSourceReaderMetricsUtil.java
@@ -1,0 +1,27 @@
+package com.pinterest.flink.connector.psc.source.metrics;
+
+import com.pinterest.psc.common.TopicUriPartition;
+import com.pinterest.psc.metrics.Metric;
+import com.pinterest.psc.metrics.MetricName;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+class MemqSourceReaderMetricsUtil {
+
+    public static final String MEMQ_CONSUMER_METRIC_GROUP = "memq-consumer-metrics";
+    public static final String BYTES_CONSUMED_TOTAL = "bytes.consumed.total";
+    public static final String NOTIFICATION_RECORDS_LAG_MAX = "notification.records.lag.max";
+
+    protected static Predicate<Map.Entry<MetricName, ? extends Metric>> createBytesConsumedFilter() {
+        return entry ->
+                entry.getKey().group().equals(MEMQ_CONSUMER_METRIC_GROUP)
+                        && entry.getKey().name().equals(BYTES_CONSUMED_TOTAL);
+    }
+
+    protected static Predicate<Map.Entry<MetricName, ? extends Metric>> createRecordsLagFilter(TopicUriPartition tp) {
+        return entry ->
+                entry.getKey().group().equals(MEMQ_CONSUMER_METRIC_GROUP)
+                        && entry.getKey().name().equals(NOTIFICATION_RECORDS_LAG_MAX);
+    }
+}

--- a/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
@@ -155,6 +155,19 @@ public class PscSourceReaderMetrics {
     }
 
     /**
+     * Returns the {@link Offset} tracker for the given partition, allowing callers to
+     * cache it and update offsets directly without repeated HashMap lookups.
+     *
+     * @param tp the topic partition to get the tracker for
+     * @return the Offset tracker
+     * @throws IllegalArgumentException if the partition is not tracked
+     */
+    public Offset getOffsetTracker(TopicUriPartition tp) {
+        checkTopicPartitionTracked(tp);
+        return offsets.get(tp);
+    }
+
+    /**
      * Update the latest committed offset of the given {@link TopicUriPartition}.
      *
      * @param tp Updating topic partition
@@ -328,9 +341,9 @@ public class PscSourceReaderMetrics {
         return it.next().tags().get("backend");
     }
 
-    private static class Offset {
-        long currentOffset;
-        long committedOffset;
+    public static class Offset {
+        public long currentOffset;
+        public long committedOffset;
 
         Offset(long currentOffset, long committedOffset) {
             this.currentOffset = currentOffset;

--- a/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
@@ -25,6 +25,7 @@ import com.pinterest.psc.consumer.PscConsumer;
 import com.pinterest.psc.exception.ClientException;
 import com.pinterest.psc.metrics.Metric;
 import com.pinterest.psc.metrics.MetricName;
+import java.util.Iterator;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
@@ -180,6 +181,17 @@ public class PscSourceReaderMetrics {
      * @param consumer Kafka consumer
      */
     public void registerNumBytesIn(PscConsumer<?, ?> consumer) throws ClientException {
+        // Skip for Memq
+        String backendType = getBackendFromTags(consumer.metrics());
+        if (!PscUtils.BACKEND_TYPE_KAFKA.equals(backendType)) {
+            LOG.warn(
+                String.format(
+                    "Unsupported backend type: \"%s\". "
+                        + "Metric \"%s\" may not be reported correctly.",
+                    backendType, MetricNames.PENDING_RECORDS));
+            return;
+        }
+
         Predicate<Map.Entry<MetricName, ? extends Metric>> filter =
                 KafkaSourceReaderMetricsUtil.createBytesConsumedFilter();
         this.bytesConsumedTotalMetric = MetricUtil.getPscMetric(consumer.metrics(), filter);
@@ -301,7 +313,11 @@ public class PscSourceReaderMetrics {
 
     private static String getBackendFromTags(Map<MetricName, ? extends Metric> metrics) {
         // sample the first entry to get the backend type
-        return metrics.keySet().iterator().next().tags().get("backend");
+        Iterator<MetricName> it = metrics.keySet().iterator();
+        if (!it.hasNext()) {
+            return "unknown";
+        }
+        return it.next().tags().get("backend");
     }
 
     private static class Offset {

--- a/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/metrics/PscSourceReaderMetrics.java
@@ -181,19 +181,21 @@ public class PscSourceReaderMetrics {
      * @param consumer Kafka consumer
      */
     public void registerNumBytesIn(PscConsumer<?, ?> consumer) throws ClientException {
-        // Skip for Memq
         String backendType = getBackendFromTags(consumer.metrics());
-        if (!PscUtils.BACKEND_TYPE_KAFKA.equals(backendType)) {
-            LOG.warn(
-                String.format(
-                    "Unsupported backend type: \"%s\". "
-                        + "Metric \"%s\" may not be reported correctly.",
-                    backendType, MetricNames.PENDING_RECORDS));
-            return;
+        Predicate<Map.Entry<MetricName, ? extends Metric>> filter;
+        switch (backendType) {
+            case PscUtils.BACKEND_TYPE_KAFKA:
+                filter = KafkaSourceReaderMetricsUtil.createBytesConsumedFilter();
+                break;
+            case PscUtils.BACKEND_TYPE_MEMQ:
+                filter = MemqSourceReaderMetricsUtil.createBytesConsumedFilter();
+                break;
+            default:
+                LOG.warn(
+                    "Unsupported backend type: \"{}\". Metric \"{}\" may not be reported correctly.",
+                    backendType, MetricNames.IO_NUM_BYTES_IN);
+                return;
         }
-
-        Predicate<Map.Entry<MetricName, ? extends Metric>> filter =
-                KafkaSourceReaderMetricsUtil.createBytesConsumedFilter();
         this.bytesConsumedTotalMetric = MetricUtil.getPscMetric(consumer.metrics(), filter);
     }
 
@@ -300,15 +302,21 @@ public class PscSourceReaderMetrics {
             case PscUtils.BACKEND_TYPE_KAFKA:
                 filter = KafkaSourceReaderMetricsUtil.createRecordLagFilter(tp);
                 break;
+            case PscUtils.BACKEND_TYPE_MEMQ:
+                filter = MemqSourceReaderMetricsUtil.createRecordsLagFilter(tp);
+                break;
             default:
                 LOG.warn(
-                        String.format(
-                                "Unsupported backend type \"%s\". "
-                                        + "Metric \"%s\" may not be reported correctly. ",
-                                backendType, MetricNames.PENDING_RECORDS));
+                        "Unsupported backend type \"{}\". Metric \"{}\" may not be reported correctly.",
+                        backendType, MetricNames.PENDING_RECORDS);
                 return null;
         }
-        return MetricUtil.getPscMetric(metrics, filter);
+        try {
+            return MetricUtil.getPscMetric(metrics, filter);
+        } catch (IllegalStateException e) {
+            LOG.debug("Metric not yet available for backend \"{}\", will retry on next poll cycle.", backendType);
+            return null;
+        }
     }
 
     private static String getBackendFromTags(Map<MetricName, ? extends Metric> metrics) {

--- a/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/reader/PscTopicUriPartitionSplitReader.java
+++ b/psc-flink/src/main/java/com/pinterest/flink/connector/psc/source/reader/PscTopicUriPartitionSplitReader.java
@@ -567,6 +567,7 @@ public class PscTopicUriPartitionSplitReader
         private Iterator<PscConsumerMessage<byte[], byte[]>> recordIterator;
         private TopicUriPartition currentTopicPartition;
         private Long currentSplitStoppingOffset;
+        private PscSourceReaderMetrics.Offset currentOffsetTracker;
 
         private PscPartitionSplitRecords(
                 PscConsumerMessagesIterable<byte[], byte[]> consumerMessagesIterable, PscSourceReaderMetrics metrics) {
@@ -592,11 +593,13 @@ public class PscTopicUriPartitionSplitReader
                 recordIterator = consumerMessagesIterable.getMessagesForTopicUriPartition(currentTopicPartition).iterator();
                 currentSplitStoppingOffset =
                         stoppingOffsets.getOrDefault(currentTopicPartition, Long.MAX_VALUE);
+                currentOffsetTracker = metrics.getOffsetTracker(currentTopicPartition);
                 return currentTopicPartition.toString();
             } else {
                 currentTopicPartition = null;
                 recordIterator = null;
                 currentSplitStoppingOffset = null;
+                currentOffsetTracker = null;
                 return null;
             }
         }
@@ -612,7 +615,7 @@ public class PscTopicUriPartitionSplitReader
                 final PscConsumerMessage<byte[], byte[]> message = recordIterator.next();
                 // Only emit records before stopping offset
                 if (message.getMessageId().getOffset() < currentSplitStoppingOffset) {
-                    metrics.recordCurrentOffset(currentTopicPartition, message.getMessageId().getOffset());
+                    currentOffsetTracker.currentOffset = message.getMessageId().getOffset();
                     return message;
                 }
             }

--- a/psc-integration-test/pom.xml
+++ b/psc-integration-test/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <kafka.version>3.4.0</kafka.version>
-        <memq.version>0.2.21</memq.version>
+        <memq.version>1.0.2</memq.version>
     </properties>
 
     <dependencies>

--- a/psc/pom.xml
+++ b/psc/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <kafka.version>3.4.0</kafka.version>
-        <memq.version>0.2.21</memq.version>
+        <memq.version>1.0.2</memq.version>
 <!--        <ts-consumer.version>1.0.0</ts-consumer.version>-->
     </properties>
 

--- a/psc/src/main/java/com/pinterest/psc/common/TopicUriPartition.java
+++ b/psc/src/main/java/com/pinterest/psc/common/TopicUriPartition.java
@@ -12,6 +12,7 @@ public class TopicUriPartition implements Comparable<TopicUriPartition>, Seriali
     private final String topicUriStr;
     private final int partition;
     private TopicUri backendTopicUri;
+    private transient int cachedHashCode;
 
     /**
      * Builds a TopicUriPartition instance with the default partition value (-1). This is meant to be used in
@@ -53,6 +54,7 @@ public class TopicUriPartition implements Comparable<TopicUriPartition>, Seriali
 
     protected void setTopicUri(TopicUri backendTopicUri) {
         this.backendTopicUri = backendTopicUri;
+        this.cachedHashCode = 0;
     }
 
     /**
@@ -106,10 +108,14 @@ public class TopicUriPartition implements Comparable<TopicUriPartition>, Seriali
 
     @Override
     public int hashCode() {
-        int result = topicUriStr.hashCode();
-        result = 31 * result + (backendTopicUri == null ? 0 : backendTopicUri.hashCode());
-        result = 31 * result + partition;
-        return result;
+        int h = cachedHashCode;
+        if (h == 0) {
+            h = topicUriStr.hashCode();
+            h = 31 * h + (backendTopicUri == null ? 0 : backendTopicUri.hashCode());
+            h = 31 * h + partition;
+            cachedHashCode = h;
+        }
+        return h;
     }
 
     @Override

--- a/psc/src/main/java/com/pinterest/psc/config/PscMetadataClientToMemqConsumerConfigConverter.java
+++ b/psc/src/main/java/com/pinterest/psc/config/PscMetadataClientToMemqConsumerConfigConverter.java
@@ -1,0 +1,26 @@
+package com.pinterest.psc.config;
+
+import com.pinterest.memq.client.commons.ConsumerConfigs;
+import com.pinterest.psc.common.TopicUri;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class PscMetadataClientToMemqConsumerConfigConverter extends PscMetadataClientToBackendMetatadataClientConfigCoverter {
+    @Override
+    protected Map<String, String> getConfigConverterMap() {
+        return new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
+            {
+                put(PscConfiguration.PSC_METADATA_CLIENT_ID, ConsumerConfigs.CLIENT_ID);
+            }
+        };
+    }
+
+    @Override
+    public Properties convert(PscConfigurationInternal pscConfigurationInternal, TopicUri topicUri) {
+        return super.convert(pscConfigurationInternal, topicUri);
+    }
+}

--- a/psc/src/main/java/com/pinterest/psc/consumer/PscConsumerMessagesIterable.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/PscConsumerMessagesIterable.java
@@ -1,7 +1,9 @@
 package com.pinterest.psc.consumer;
 
 import com.pinterest.psc.common.TopicUriPartition;
+import com.pinterest.psc.logging.PscLogger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -13,11 +15,18 @@ import java.util.function.Consumer;
 
 public class PscConsumerMessagesIterable<K, V> implements Iterable<PscConsumerMessage<K, V>> {
 
+    private static final PscLogger logger = PscLogger.getLogger(PscConsumerMessagesIterable.class);
+
     List<PscConsumerMessage<K, V>> messages;
     Map<TopicUriPartition, List<PscConsumerMessage<K, V>>> messagesByTopicUriPartition;
 
     public PscConsumerMessagesIterable(PscConsumerPollMessageIterator<K, V> iterator) {
         this.messages = iterator.asList();
+        try {
+            iterator.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close poll message iterator", e);
+        }
         this.messagesByTopicUriPartition = new HashMap<>();
         for (PscConsumerMessage<K, V> message : messages) {
             TopicUriPartition topicUriPartition = message.getMessageId().getTopicUriPartition();

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/MemqTopicUri.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/MemqTopicUri.java
@@ -9,7 +9,7 @@ public class MemqTopicUri extends BaseTopicUri {
     public static final String PLAINTEXT_PROTOCOL = "plaintext";
     public static final String SECURE_PROTOCOL = "secure";
 
-    MemqTopicUri(TopicUri topicUri) {
+    public MemqTopicUri(TopicUri topicUri) {
         super(topicUri);
     }
 

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
@@ -601,6 +601,7 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
     public void close() throws ConsumerException {
         if (memqConsumer == null)
             throw new ConsumerException("[Memq] Consumer is not initialized prior to call to close().");
+        scheduler.shutdown();
         currentSubscription.clear();
         try {
             memqConsumer.close();

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
@@ -642,7 +642,8 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
         Map<Integer, Long> startOffsets = memqConsumer
                 .getEarliestOffsets(partitionToTopicUriPartition.keySet());
         return startOffsets.entrySet().stream().collect(Collectors
-                .toMap(entry -> partitionToTopicUriPartition.get(entry.getKey()), Map.Entry::getValue));
+                .toMap(entry -> partitionToTopicUriPartition.get(entry.getKey()),
+                       entry -> kafkaOffsetToComposite(entry.getValue())));
     }
 
     @Override
@@ -656,7 +657,8 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
         Map<Integer, Long> endOffsets = memqConsumer
                 .getLatestOffsets(partitionToTopicUriPartition.keySet());
         return endOffsets.entrySet().stream().collect(Collectors
-                .toMap(entry -> partitionToTopicUriPartition.get(entry.getKey()), Map.Entry::getValue));
+                .toMap(entry -> partitionToTopicUriPartition.get(entry.getKey()),
+                       entry -> kafkaOffsetToComposite(entry.getValue())));
     }
 
     @Override
@@ -796,6 +798,16 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
 
     private boolean isCurrentTopicPartition(TopicUriPartition topicUriPartition) {
         return this.currentSubscription.contains(topicUriPartition.getTopicUri()) || this.currentAssignment.contains(topicUriPartition);
+    }
+
+    /**
+     * Converts a raw Kafka notification offset to a composite MemqOffset (with message offset 0).
+     * All offsets exposed by PscMemqConsumer must be in composite format so that
+     * {@link #seekToOffset} can correctly decode them back via
+     * {@link MemqOffset#convertPscOffsetToMemqOffset}.
+     */
+    private static long kafkaOffsetToComposite(long kafkaOffset) {
+        return new MemqOffset(kafkaOffset, 0).toLong();
     }
 
     private MemqConsumer<byte[], byte[]> getMetadataConsumer(TopicUri topicUri) throws ConsumerException {

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
@@ -29,8 +29,10 @@ import com.pinterest.psc.consumer.PscConsumerPollMessageIterator;
 import com.pinterest.psc.exception.consumer.ConsumerException;
 import com.pinterest.psc.exception.consumer.WakeupException;
 import com.pinterest.psc.logging.PscLogger;
+import com.pinterest.psc.common.PscUtils;
 import com.pinterest.psc.metrics.Metric;
 import com.pinterest.psc.metrics.MetricName;
+import com.pinterest.psc.metrics.MetricValueProvider;
 import com.pinterest.psc.metrics.PscMetricRegistryManager;
 import com.pinterest.psc.metrics.PscMetrics;
 
@@ -66,6 +68,7 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
     private TopicUri topicUri;
 
     private final Map<Integer, MemqOffset> initialSeekOffsets = new ConcurrentHashMap<>();
+    private final MetricValueProvider metricValueProvider = new MetricValueProvider();
 
     public PscMemqConsumer() {
     }
@@ -714,7 +717,42 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() throws ConsumerException {
-        return Collections.emptyMap();
+        if (memqConsumer == null) {
+            return Collections.emptyMap();
+        }
+
+        MetricRegistry registry = memqConsumer.getMetricRegistry();
+        if (registry == null) {
+            return Collections.emptyMap();
+        }
+
+        metricValueProvider.reset();
+        for (Map.Entry<String, com.codahale.metrics.Metric> entry : registry.getMetrics().entrySet()) {
+            String name = entry.getKey();
+            com.codahale.metrics.Metric dropwizardMetric = entry.getValue();
+
+            Map<String, String> tags = new HashMap<>();
+            tags.put("backend", PscUtils.BACKEND_TYPE_MEMQ);
+
+            MetricName metricName = new MetricName(name, "memq-consumer-metrics", "", tags);
+            metricValueProvider.updateMetric(metricName, getDropwizardMetricValue(dropwizardMetric));
+        }
+
+        return metricValueProvider.getMetrics();
+    }
+
+    private static Object getDropwizardMetricValue(com.codahale.metrics.Metric metric) {
+        if (metric instanceof Counter)
+            return ((Counter) metric).getCount();
+        if (metric instanceof Gauge)
+            return ((Gauge<?>) metric).getValue();
+        if (metric instanceof Meter)
+            return ((Meter) metric).getCount();
+        if (metric instanceof Histogram)
+            return ((Histogram) metric).getSnapshot().getMax();
+        if (metric instanceof Timer)
+            return ((Timer) metric).getSnapshot().getMax();
+        return -1L;
     }
 
     /**

--- a/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
+++ b/psc/src/main/java/com/pinterest/psc/consumer/memq/PscMemqConsumer.java
@@ -32,7 +32,6 @@ import com.pinterest.psc.logging.PscLogger;
 import com.pinterest.psc.common.PscUtils;
 import com.pinterest.psc.metrics.Metric;
 import com.pinterest.psc.metrics.MetricName;
-import com.pinterest.psc.metrics.MetricValueProvider;
 import com.pinterest.psc.metrics.PscMetricRegistryManager;
 import com.pinterest.psc.metrics.PscMetrics;
 
@@ -57,6 +56,7 @@ import java.util.stream.Collectors;
 public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
 
     public static final String END_OF_BATCH_EVENT = "end_of_batch";
+    private static final String MEMQ_CONSUMER_METRIC_GROUP = "memq-consumer-metrics";
 
     private static final PscLogger logger = PscLogger.getLogger(PscMemqConsumer.class);
     @VisibleForTesting
@@ -68,7 +68,6 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
     private TopicUri topicUri;
 
     private final Map<Integer, MemqOffset> initialSeekOffsets = new ConcurrentHashMap<>();
-    private final MetricValueProvider metricValueProvider = new MetricValueProvider();
 
     public PscMemqConsumer() {
     }
@@ -726,7 +725,7 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
             return Collections.emptyMap();
         }
 
-        metricValueProvider.reset();
+        Map<MetricName, Metric> result = new HashMap<>();
         for (Map.Entry<String, com.codahale.metrics.Metric> entry : registry.getMetrics().entrySet()) {
             String name = entry.getKey();
             com.codahale.metrics.Metric dropwizardMetric = entry.getValue();
@@ -734,25 +733,40 @@ public class PscMemqConsumer<K, V> extends PscBackendConsumer<K, V> {
             Map<String, String> tags = new HashMap<>();
             tags.put("backend", PscUtils.BACKEND_TYPE_MEMQ);
 
-            MetricName metricName = new MetricName(name, "memq-consumer-metrics", "", tags);
-            metricValueProvider.updateMetric(metricName, getDropwizardMetricValue(dropwizardMetric));
+            MetricName metricName = new MetricName(name, MEMQ_CONSUMER_METRIC_GROUP, "", tags);
+            result.put(metricName, new LiveDropwizardMetric(metricName, dropwizardMetric));
         }
 
-        return metricValueProvider.getMetrics();
+        return result;
     }
 
-    private static Object getDropwizardMetricValue(com.codahale.metrics.Metric metric) {
-        if (metric instanceof Counter)
-            return ((Counter) metric).getCount();
-        if (metric instanceof Gauge)
-            return ((Gauge<?>) metric).getValue();
-        if (metric instanceof Meter)
-            return ((Meter) metric).getCount();
-        if (metric instanceof Histogram)
-            return ((Histogram) metric).getSnapshot().getMax();
-        if (metric instanceof Timer)
-            return ((Timer) metric).getSnapshot().getMax();
-        return -1L;
+    /**
+     * A PSC Metric backed by a live Dropwizard metric reference.
+     * Each call to {@link #metricValue()} reads the current value from the
+     * underlying Dropwizard metric rather than returning a stale snapshot.
+     */
+    private static class LiveDropwizardMetric extends Metric {
+        private final com.codahale.metrics.Metric dropwizardMetric;
+
+        LiveDropwizardMetric(MetricName metricName, com.codahale.metrics.Metric dropwizardMetric) {
+            super(metricName, null);
+            this.dropwizardMetric = dropwizardMetric;
+        }
+
+        @Override
+        public Object metricValue() {
+            if (dropwizardMetric instanceof Counter)
+                return ((Counter) dropwizardMetric).getCount();
+            if (dropwizardMetric instanceof Gauge)
+                return ((Gauge<?>) dropwizardMetric).getValue();
+            if (dropwizardMetric instanceof Meter)
+                return ((Meter) dropwizardMetric).getCount();
+            if (dropwizardMetric instanceof Histogram)
+                return ((Histogram) dropwizardMetric).getSnapshot().getMax();
+            if (dropwizardMetric instanceof Timer)
+                return ((Timer) dropwizardMetric).getSnapshot().getMax();
+            return -1L;
+        }
     }
 
     /**

--- a/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeoutException;
 public class PscMemqMetadataClient extends PscBackendMetadataClient {
 
     private static final PscLogger logger = PscLogger.getLogger(PscMemqMetadataClient.class);
-    private MemqConsumer<byte[], byte[]> memqConsumer;
+    protected MemqConsumer<byte[], byte[]> memqConsumer;
 
     @Override
     public void initialize(

--- a/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -52,9 +51,9 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
                 .convert(pscConfigurationInternal, topicUri);
         properties.setProperty(ConsumerConfigs.BOOTSTRAP_SERVERS, discoveryConfig.getConnect());
         properties.setProperty(ConsumerConfigs.CLIENT_ID,
-                pscConfigurationInternal.getMetadataClientId() + "_metadata");
+                pscConfigurationInternal.getMetadataClientId());
         properties.setProperty(ConsumerConfigs.GROUP_ID,
-                "psc-metadata-client-" + UUID.randomUUID());
+                pscConfigurationInternal.getMetadataClientId());
         properties.setProperty(ConsumerConfigs.KEY_DESERIALIZER_CLASS_KEY,
                 ByteArrayDeserializer.class.getName());
         properties.put(ConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());

--- a/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
@@ -1,0 +1,267 @@
+package com.pinterest.psc.metadata.client.memq;
+
+import com.pinterest.memq.client.commons.ConsumerConfigs;
+import com.pinterest.memq.client.commons.serde.ByteArrayDeserializer;
+import com.pinterest.memq.client.consumer.MemqConsumer;
+import com.pinterest.psc.common.BaseTopicUri;
+import com.pinterest.psc.common.TopicRn;
+import com.pinterest.psc.common.TopicUri;
+import com.pinterest.psc.common.TopicUriPartition;
+import com.pinterest.psc.config.PscConfigurationInternal;
+import com.pinterest.psc.config.PscMetadataClientToMemqConsumerConfigConverter;
+import com.pinterest.psc.consumer.memq.MemqTopicUri;
+import com.pinterest.psc.environment.Environment;
+import com.pinterest.psc.exception.startup.ConfigurationException;
+import com.pinterest.psc.logging.PscLogger;
+import com.pinterest.psc.metadata.MetadataUtils;
+import com.pinterest.psc.metadata.TopicUriMetadata;
+import com.pinterest.psc.metadata.client.PscBackendMetadataClient;
+import com.pinterest.psc.metadata.client.PscMetadataClient;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A Memq-specific implementation of the {@link PscBackendMetadataClient}.
+ * Uses short-lived {@link MemqConsumer} instances to query metadata since Memq
+ * does not have a dedicated admin client.
+ */
+public class PscMemqMetadataClient extends PscBackendMetadataClient {
+
+    private static final PscLogger logger = PscLogger.getLogger(PscMemqMetadataClient.class);
+    private Properties baseProperties;
+
+    @Override
+    public void initialize(
+            TopicUri topicUri,
+            Environment env,
+            PscConfigurationInternal pscConfigurationInternal
+    ) throws ConfigurationException {
+        super.initialize(topicUri, env, pscConfigurationInternal);
+        baseProperties = new PscMetadataClientToMemqConsumerConfigConverter()
+                .convert(pscConfigurationInternal, topicUri);
+        baseProperties.setProperty(ConsumerConfigs.BOOTSTRAP_SERVERS, discoveryConfig.getConnect());
+        baseProperties.setProperty(ConsumerConfigs.CLIENT_ID, pscConfigurationInternal.getMetadataClientId());
+        baseProperties.setProperty(ConsumerConfigs.KEY_DESERIALIZER_CLASS_KEY,
+                ByteArrayDeserializer.class.getName());
+        baseProperties.put(ConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
+        baseProperties.setProperty(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_KEY,
+                ByteArrayDeserializer.class.getName());
+        baseProperties.put(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
+        baseProperties.setProperty(ConsumerConfigs.DIRECT_CONSUMER, "false");
+        logger.info("Initialized PscMemqMetadataClient with base properties: " + baseProperties);
+    }
+
+    @Override
+    public List<TopicRn> listTopicRns(Duration duration)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        throw new UnsupportedOperationException(
+                "[Memq] Listing all topics is not supported by the Memq backend.");
+    }
+
+    @Override
+    public Map<TopicUri, TopicUriMetadata> describeTopicUris(
+            Collection<TopicUri> topicUris,
+            Duration duration
+    ) throws ExecutionException, InterruptedException, TimeoutException {
+        Map<TopicUri, TopicUriMetadata> result = new HashMap<>();
+        for (TopicUri tu : topicUris) {
+            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(tu.getTopic())) {
+                List<Integer> partitions = consumer.getPartition();
+                List<TopicUriPartition> topicUriPartitions = new ArrayList<>();
+                for (int partition : partitions) {
+                    topicUriPartitions.add(createMemqTopicUriPartition(tu, partition));
+                }
+                result.put(tu, new TopicUriMetadata(tu, topicUriPartitions));
+            } catch (IOException e) {
+                throw new ExecutionException("Failed to close Memq metadata consumer for " + tu, e);
+            } catch (Exception e) {
+                throw new ExecutionException("Failed to describe topic " + tu, e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<TopicUriPartition, Long> listOffsets(
+            Map<TopicUriPartition, PscMetadataClient.MetadataClientOption> topicUriPartitionsAndOptions,
+            Duration duration
+    ) throws ExecutionException, InterruptedException, TimeoutException {
+        Map<String, Set<Integer>> earliestByTopic = new HashMap<>();
+        Map<String, Set<Integer>> latestByTopic = new HashMap<>();
+        Map<String, TopicUri> topicToUri = new HashMap<>();
+
+        for (Map.Entry<TopicUriPartition, PscMetadataClient.MetadataClientOption> entry :
+                topicUriPartitionsAndOptions.entrySet()) {
+            TopicUriPartition tup = entry.getKey();
+            String topic = tup.getTopicUri().getTopic();
+            topicToUri.put(topic, tup.getTopicUri());
+
+            if (entry.getValue() == PscMetadataClient.MetadataClientOption.OFFSET_SPEC_EARLIEST) {
+                earliestByTopic.computeIfAbsent(topic, k -> new HashSet<>()).add(tup.getPartition());
+            } else if (entry.getValue() == PscMetadataClient.MetadataClientOption.OFFSET_SPEC_LATEST) {
+                latestByTopic.computeIfAbsent(topic, k -> new HashSet<>()).add(tup.getPartition());
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported MetadataClientOption for listOffsets(): " + entry.getValue());
+            }
+        }
+
+        Map<TopicUriPartition, Long> result = new HashMap<>();
+        Set<String> allTopics = new HashSet<>();
+        allTopics.addAll(earliestByTopic.keySet());
+        allTopics.addAll(latestByTopic.keySet());
+
+        for (String topic : allTopics) {
+            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic)) {
+                Set<Integer> earliestPartitions = earliestByTopic.getOrDefault(topic, new HashSet<>());
+                if (!earliestPartitions.isEmpty()) {
+                    Map<Integer, Long> offsets = consumer.getEarliestOffsets(earliestPartitions);
+                    for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
+                        TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                        result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
+                    }
+                }
+
+                Set<Integer> latestPartitions = latestByTopic.getOrDefault(topic, new HashSet<>());
+                if (!latestPartitions.isEmpty()) {
+                    Map<Integer, Long> offsets = consumer.getLatestOffsets(latestPartitions);
+                    for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
+                        TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                        result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
+                    }
+                }
+            } catch (IOException e) {
+                throw new ExecutionException("Failed to close Memq metadata consumer for topic " + topic, e);
+            } catch (Exception e) {
+                throw new ExecutionException("Failed to list offsets for topic " + topic, e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<TopicUriPartition, Long> listOffsetsForTimestamps(
+            Map<TopicUriPartition, Long> topicUriPartitionsAndTimes,
+            Duration duration
+    ) throws ExecutionException, InterruptedException, TimeoutException {
+        Map<String, Map<Integer, Long>> timestampsByTopic = new HashMap<>();
+        Map<String, Map<Integer, TopicUriPartition>> partitionLookupByTopic = new HashMap<>();
+
+        for (Map.Entry<TopicUriPartition, Long> entry : topicUriPartitionsAndTimes.entrySet()) {
+            TopicUriPartition tup = entry.getKey();
+            String topic = tup.getTopicUri().getTopic();
+            timestampsByTopic.computeIfAbsent(topic, k -> new HashMap<>())
+                    .put(tup.getPartition(), entry.getValue());
+            partitionLookupByTopic.computeIfAbsent(topic, k -> new HashMap<>())
+                    .put(tup.getPartition(), tup);
+        }
+
+        Map<TopicUriPartition, Long> result = new HashMap<>();
+        for (Map.Entry<String, Map<Integer, Long>> entry : timestampsByTopic.entrySet()) {
+            String topic = entry.getKey();
+            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic)) {
+                Map<Integer, Long> offsets = consumer.offsetsOfTimestamps(entry.getValue());
+                Map<Integer, TopicUriPartition> partitionLookup = partitionLookupByTopic.get(topic);
+                for (Map.Entry<Integer, Long> offsetEntry : offsets.entrySet()) {
+                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                    result.put(
+                            createMemqTopicUriPartition(topicRn, offsetEntry.getKey()),
+                            offsetEntry.getValue()
+                    );
+                }
+            } catch (IOException e) {
+                throw new ExecutionException(
+                        "Failed to close Memq metadata consumer for topic " + topic, e);
+            } catch (Exception e) {
+                throw new ExecutionException(
+                        "Failed to list offsets for timestamps for topic " + topic, e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<TopicUriPartition, Long> listOffsetsForConsumerGroup(
+            String consumerGroupId,
+            Collection<TopicUriPartition> topicUriPartitions,
+            Duration duration
+    ) throws ExecutionException, InterruptedException, TimeoutException {
+        Map<String, Set<Integer>> partitionsByTopic = new HashMap<>();
+        for (TopicUriPartition tup : topicUriPartitions) {
+            String topic = tup.getTopicUri().getTopic();
+            partitionsByTopic.computeIfAbsent(topic, k -> new HashSet<>()).add(tup.getPartition());
+        }
+
+        Map<TopicUriPartition, Long> result = new HashMap<>();
+        for (Map.Entry<String, Set<Integer>> entry : partitionsByTopic.entrySet()) {
+            String topic = entry.getKey();
+            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic, consumerGroupId)) {
+                for (int partition : entry.getValue()) {
+                    long committedOffset = consumer.committed(partition);
+                    if (committedOffset == -1L) {
+                        logger.warn(
+                                "Consumer group {} has no committed offset for topic {} partition {}",
+                                consumerGroupId, topic, partition
+                        );
+                        continue;
+                    }
+                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                    result.put(createMemqTopicUriPartition(topicRn, partition), committedOffset);
+                }
+            } catch (IOException e) {
+                throw new ExecutionException(
+                        "Failed to close Memq metadata consumer for topic " + topic, e);
+            } catch (Exception e) {
+                throw new ExecutionException(
+                        "Failed to list consumer group offsets for topic " + topic, e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        logger.info("Closed PscMemqMetadataClient");
+    }
+
+    private MemqConsumer<byte[], byte[]> createConsumer(String topic) throws Exception {
+        return createConsumer(topic, null);
+    }
+
+    private MemqConsumer<byte[], byte[]> createConsumer(String topic, String groupId) throws Exception {
+        Properties props = new Properties();
+        props.putAll(baseProperties);
+        props.setProperty(ConsumerConfigs.CLIENT_ID,
+                baseProperties.getProperty(ConsumerConfigs.CLIENT_ID) + "_metadata");
+        if (groupId != null) {
+            props.setProperty(ConsumerConfigs.GROUP_ID, groupId);
+        } else {
+            props.setProperty(ConsumerConfigs.GROUP_ID,
+                    topic + "_metadata_cg_" + ThreadLocalRandom.current().nextInt());
+        }
+        MemqConsumer<byte[], byte[]> consumer = new MemqConsumer<>(props);
+        consumer.subscribe(topic);
+        return consumer;
+    }
+
+    private TopicUriPartition createMemqTopicUriPartition(TopicRn topicRn, int partition) {
+        return new TopicUriPartition(
+                new MemqTopicUri(new BaseTopicUri(topicUri.getProtocol(), topicRn)), partition);
+    }
+
+    private TopicUriPartition createMemqTopicUriPartition(TopicUri topicUri, int partition) {
+        return new TopicUriPartition(new MemqTopicUri(topicUri), partition);
+    }
+}

--- a/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
@@ -9,6 +9,7 @@ import com.pinterest.psc.common.TopicUri;
 import com.pinterest.psc.common.TopicUriPartition;
 import com.pinterest.psc.config.PscConfigurationInternal;
 import com.pinterest.psc.config.PscMetadataClientToMemqConsumerConfigConverter;
+import com.pinterest.psc.consumer.memq.MemqOffset;
 import com.pinterest.psc.consumer.memq.MemqTopicUri;
 import com.pinterest.psc.environment.Environment;
 import com.pinterest.psc.exception.startup.ConfigurationException;
@@ -130,7 +131,7 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
                 Map<Integer, Long> offsets = memqConsumer.getEarliestOffsets(earliestPartitions);
                 for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
                     TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
+                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), kafkaOffsetToComposite(e.getValue()));
                 }
             }
 
@@ -139,7 +140,7 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
                 Map<Integer, Long> offsets = memqConsumer.getLatestOffsets(latestPartitions);
                 for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
                     TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
+                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), kafkaOffsetToComposite(e.getValue()));
                 }
             }
         }
@@ -169,7 +170,7 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
                 TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
                 result.put(
                         createMemqTopicUriPartition(topicRn, offsetEntry.getKey()),
-                        offsetEntry.getValue()
+                        kafkaOffsetToComposite(offsetEntry.getValue())
                 );
             }
         }
@@ -202,7 +203,7 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
                     continue;
                 }
                 TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                result.put(createMemqTopicUriPartition(topicRn, partition), committedOffset);
+                result.put(createMemqTopicUriPartition(topicRn, partition), kafkaOffsetToComposite(committedOffset));
             }
         }
         return result;
@@ -230,5 +231,9 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
 
     private TopicUriPartition createMemqTopicUriPartition(TopicUri topicUri, int partition) {
         return new TopicUriPartition(new MemqTopicUri(topicUri), partition);
+    }
+
+    private static long kafkaOffsetToComposite(long kafkaOffset) {
+        return new MemqOffset(kafkaOffset, 0).toLong();
     }
 }

--- a/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java
@@ -28,19 +28,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
 /**
  * A Memq-specific implementation of the {@link PscBackendMetadataClient}.
- * Uses short-lived {@link MemqConsumer} instances to query metadata since Memq
- * does not have a dedicated admin client.
+ * Uses a {@link MemqConsumer} to query metadata since Memq does not have a dedicated admin client.
  */
 public class PscMemqMetadataClient extends PscBackendMetadataClient {
 
     private static final PscLogger logger = PscLogger.getLogger(PscMemqMetadataClient.class);
-    private Properties baseProperties;
+    private MemqConsumer<byte[], byte[]> memqConsumer;
 
     @Override
     public void initialize(
@@ -49,18 +48,26 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
             PscConfigurationInternal pscConfigurationInternal
     ) throws ConfigurationException {
         super.initialize(topicUri, env, pscConfigurationInternal);
-        baseProperties = new PscMetadataClientToMemqConsumerConfigConverter()
+        Properties properties = new PscMetadataClientToMemqConsumerConfigConverter()
                 .convert(pscConfigurationInternal, topicUri);
-        baseProperties.setProperty(ConsumerConfigs.BOOTSTRAP_SERVERS, discoveryConfig.getConnect());
-        baseProperties.setProperty(ConsumerConfigs.CLIENT_ID, pscConfigurationInternal.getMetadataClientId());
-        baseProperties.setProperty(ConsumerConfigs.KEY_DESERIALIZER_CLASS_KEY,
+        properties.setProperty(ConsumerConfigs.BOOTSTRAP_SERVERS, discoveryConfig.getConnect());
+        properties.setProperty(ConsumerConfigs.CLIENT_ID,
+                pscConfigurationInternal.getMetadataClientId() + "_metadata");
+        properties.setProperty(ConsumerConfigs.GROUP_ID,
+                "psc-metadata-client-" + UUID.randomUUID());
+        properties.setProperty(ConsumerConfigs.KEY_DESERIALIZER_CLASS_KEY,
                 ByteArrayDeserializer.class.getName());
-        baseProperties.put(ConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
-        baseProperties.setProperty(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_KEY,
+        properties.put(ConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
+        properties.setProperty(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_KEY,
                 ByteArrayDeserializer.class.getName());
-        baseProperties.put(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
-        baseProperties.setProperty(ConsumerConfigs.DIRECT_CONSUMER, "false");
-        logger.info("Initialized PscMemqMetadataClient with base properties: " + baseProperties);
+        properties.put(ConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIGS_KEY, new Properties());
+        properties.setProperty(ConsumerConfigs.DIRECT_CONSUMER, "false");
+        try {
+            this.memqConsumer = new MemqConsumer<>(properties);
+        } catch (Exception e) {
+            throw new ConfigurationException("Failed to create Memq consumer for metadata client", e);
+        }
+        logger.info("Initialized PscMemqMetadataClient with properties: " + properties);
     }
 
     @Override
@@ -77,18 +84,13 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
     ) throws ExecutionException, InterruptedException, TimeoutException {
         Map<TopicUri, TopicUriMetadata> result = new HashMap<>();
         for (TopicUri tu : topicUris) {
-            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(tu.getTopic())) {
-                List<Integer> partitions = consumer.getPartition();
-                List<TopicUriPartition> topicUriPartitions = new ArrayList<>();
-                for (int partition : partitions) {
-                    topicUriPartitions.add(createMemqTopicUriPartition(tu, partition));
-                }
-                result.put(tu, new TopicUriMetadata(tu, topicUriPartitions));
-            } catch (IOException e) {
-                throw new ExecutionException("Failed to close Memq metadata consumer for " + tu, e);
-            } catch (Exception e) {
-                throw new ExecutionException("Failed to describe topic " + tu, e);
+            subscribe(tu.getTopic());
+            List<Integer> partitions = memqConsumer.getPartition();
+            List<TopicUriPartition> topicUriPartitions = new ArrayList<>();
+            for (int partition : partitions) {
+                topicUriPartitions.add(createMemqTopicUriPartition(tu, partition));
             }
+            result.put(tu, new TopicUriMetadata(tu, topicUriPartitions));
         }
         return result;
     }
@@ -100,13 +102,11 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
     ) throws ExecutionException, InterruptedException, TimeoutException {
         Map<String, Set<Integer>> earliestByTopic = new HashMap<>();
         Map<String, Set<Integer>> latestByTopic = new HashMap<>();
-        Map<String, TopicUri> topicToUri = new HashMap<>();
 
         for (Map.Entry<TopicUriPartition, PscMetadataClient.MetadataClientOption> entry :
                 topicUriPartitionsAndOptions.entrySet()) {
             TopicUriPartition tup = entry.getKey();
             String topic = tup.getTopicUri().getTopic();
-            topicToUri.put(topic, tup.getTopicUri());
 
             if (entry.getValue() == PscMetadataClient.MetadataClientOption.OFFSET_SPEC_EARLIEST) {
                 earliestByTopic.computeIfAbsent(topic, k -> new HashSet<>()).add(tup.getPartition());
@@ -124,28 +124,24 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
         allTopics.addAll(latestByTopic.keySet());
 
         for (String topic : allTopics) {
-            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic)) {
-                Set<Integer> earliestPartitions = earliestByTopic.getOrDefault(topic, new HashSet<>());
-                if (!earliestPartitions.isEmpty()) {
-                    Map<Integer, Long> offsets = consumer.getEarliestOffsets(earliestPartitions);
-                    for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
-                        TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                        result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
-                    }
-                }
+            subscribe(topic);
 
-                Set<Integer> latestPartitions = latestByTopic.getOrDefault(topic, new HashSet<>());
-                if (!latestPartitions.isEmpty()) {
-                    Map<Integer, Long> offsets = consumer.getLatestOffsets(latestPartitions);
-                    for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
-                        TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                        result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
-                    }
+            Set<Integer> earliestPartitions = earliestByTopic.getOrDefault(topic, new HashSet<>());
+            if (!earliestPartitions.isEmpty()) {
+                Map<Integer, Long> offsets = memqConsumer.getEarliestOffsets(earliestPartitions);
+                for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
+                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
                 }
-            } catch (IOException e) {
-                throw new ExecutionException("Failed to close Memq metadata consumer for topic " + topic, e);
-            } catch (Exception e) {
-                throw new ExecutionException("Failed to list offsets for topic " + topic, e);
+            }
+
+            Set<Integer> latestPartitions = latestByTopic.getOrDefault(topic, new HashSet<>());
+            if (!latestPartitions.isEmpty()) {
+                Map<Integer, Long> offsets = memqConsumer.getLatestOffsets(latestPartitions);
+                for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
+                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                    result.put(createMemqTopicUriPartition(topicRn, e.getKey()), e.getValue());
+                }
             }
         }
         return result;
@@ -157,36 +153,25 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
             Duration duration
     ) throws ExecutionException, InterruptedException, TimeoutException {
         Map<String, Map<Integer, Long>> timestampsByTopic = new HashMap<>();
-        Map<String, Map<Integer, TopicUriPartition>> partitionLookupByTopic = new HashMap<>();
 
         for (Map.Entry<TopicUriPartition, Long> entry : topicUriPartitionsAndTimes.entrySet()) {
             TopicUriPartition tup = entry.getKey();
             String topic = tup.getTopicUri().getTopic();
             timestampsByTopic.computeIfAbsent(topic, k -> new HashMap<>())
                     .put(tup.getPartition(), entry.getValue());
-            partitionLookupByTopic.computeIfAbsent(topic, k -> new HashMap<>())
-                    .put(tup.getPartition(), tup);
         }
 
         Map<TopicUriPartition, Long> result = new HashMap<>();
         for (Map.Entry<String, Map<Integer, Long>> entry : timestampsByTopic.entrySet()) {
             String topic = entry.getKey();
-            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic)) {
-                Map<Integer, Long> offsets = consumer.offsetsOfTimestamps(entry.getValue());
-                Map<Integer, TopicUriPartition> partitionLookup = partitionLookupByTopic.get(topic);
-                for (Map.Entry<Integer, Long> offsetEntry : offsets.entrySet()) {
-                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                    result.put(
-                            createMemqTopicUriPartition(topicRn, offsetEntry.getKey()),
-                            offsetEntry.getValue()
-                    );
-                }
-            } catch (IOException e) {
-                throw new ExecutionException(
-                        "Failed to close Memq metadata consumer for topic " + topic, e);
-            } catch (Exception e) {
-                throw new ExecutionException(
-                        "Failed to list offsets for timestamps for topic " + topic, e);
+            subscribe(topic);
+            Map<Integer, Long> offsets = memqConsumer.offsetsOfTimestamps(entry.getValue());
+            for (Map.Entry<Integer, Long> offsetEntry : offsets.entrySet()) {
+                TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                result.put(
+                        createMemqTopicUriPartition(topicRn, offsetEntry.getKey()),
+                        offsetEntry.getValue()
+                );
             }
         }
         return result;
@@ -207,25 +192,18 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
         Map<TopicUriPartition, Long> result = new HashMap<>();
         for (Map.Entry<String, Set<Integer>> entry : partitionsByTopic.entrySet()) {
             String topic = entry.getKey();
-            try (MemqConsumer<byte[], byte[]> consumer = createConsumer(topic, consumerGroupId)) {
-                for (int partition : entry.getValue()) {
-                    long committedOffset = consumer.committed(partition);
-                    if (committedOffset == -1L) {
-                        logger.warn(
-                                "Consumer group {} has no committed offset for topic {} partition {}",
-                                consumerGroupId, topic, partition
-                        );
-                        continue;
-                    }
-                    TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
-                    result.put(createMemqTopicUriPartition(topicRn, partition), committedOffset);
+            subscribe(topic);
+            for (int partition : entry.getValue()) {
+                long committedOffset = memqConsumer.committed(partition);
+                if (committedOffset == -1L) {
+                    logger.warn(
+                            "Consumer group {} has no committed offset for topic {} partition {}",
+                            consumerGroupId, topic, partition
+                    );
+                    continue;
                 }
-            } catch (IOException e) {
-                throw new ExecutionException(
-                        "Failed to close Memq metadata consumer for topic " + topic, e);
-            } catch (Exception e) {
-                throw new ExecutionException(
-                        "Failed to list consumer group offsets for topic " + topic, e);
+                TopicRn topicRn = MetadataUtils.createTopicRn(topicUri, topic);
+                result.put(createMemqTopicUriPartition(topicRn, partition), committedOffset);
             }
         }
         return result;
@@ -233,27 +211,17 @@ public class PscMemqMetadataClient extends PscBackendMetadataClient {
 
     @Override
     public void close() throws IOException {
+        if (memqConsumer != null)
+            memqConsumer.close();
         logger.info("Closed PscMemqMetadataClient");
     }
 
-    private MemqConsumer<byte[], byte[]> createConsumer(String topic) throws Exception {
-        return createConsumer(topic, null);
-    }
-
-    private MemqConsumer<byte[], byte[]> createConsumer(String topic, String groupId) throws Exception {
-        Properties props = new Properties();
-        props.putAll(baseProperties);
-        props.setProperty(ConsumerConfigs.CLIENT_ID,
-                baseProperties.getProperty(ConsumerConfigs.CLIENT_ID) + "_metadata");
-        if (groupId != null) {
-            props.setProperty(ConsumerConfigs.GROUP_ID, groupId);
-        } else {
-            props.setProperty(ConsumerConfigs.GROUP_ID,
-                    topic + "_metadata_cg_" + ThreadLocalRandom.current().nextInt());
+    private void subscribe(String topic) throws ExecutionException {
+        try {
+            memqConsumer.subscribe(topic);
+        } catch (Exception e) {
+            throw new ExecutionException("Failed to subscribe to Memq topic " + topic, e);
         }
-        MemqConsumer<byte[], byte[]> consumer = new MemqConsumer<>(props);
-        consumer.subscribe(topic);
-        return consumer;
     }
 
     private TopicUriPartition createMemqTopicUriPartition(TopicRn topicRn, int partition) {

--- a/psc/src/main/java/com/pinterest/psc/metadata/creation/PscMemqMetadataClientCreator.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/creation/PscMemqMetadataClientCreator.java
@@ -1,0 +1,37 @@
+package com.pinterest.psc.metadata.creation;
+
+import com.pinterest.psc.common.PscUtils;
+import com.pinterest.psc.common.TopicUri;
+import com.pinterest.psc.config.PscConfigurationInternal;
+import com.pinterest.psc.consumer.memq.MemqTopicUri;
+import com.pinterest.psc.environment.Environment;
+import com.pinterest.psc.exception.startup.ConfigurationException;
+import com.pinterest.psc.exception.startup.TopicUriSyntaxException;
+import com.pinterest.psc.logging.PscLogger;
+import com.pinterest.psc.metadata.client.memq.PscMemqMetadataClient;
+
+/**
+ * A class that creates a {@link com.pinterest.psc.metadata.client.PscBackendMetadataClient} for Memq.
+ */
+@PscMetadataClientCreatorPlugin(backend = PscUtils.BACKEND_TYPE_MEMQ, priority = 1)
+public class PscMemqMetadataClientCreator extends PscBackendMetadataClientCreator {
+
+    private static final PscLogger logger = PscLogger.getLogger(PscMemqMetadataClientCreator.class);
+
+    @Override
+    public PscMemqMetadataClient create(Environment env, PscConfigurationInternal pscConfigurationInternal, TopicUri clusterUri) throws ConfigurationException {
+        logger.info("Creating Memq metadata client for clusterUri: " + clusterUri);
+        PscMemqMetadataClient pscMemqMetadataClient = new PscMemqMetadataClient();
+        pscMemqMetadataClient.initialize(
+                clusterUri,
+                env,
+                pscConfigurationInternal
+        );
+        return pscMemqMetadataClient;
+    }
+
+    @Override
+    public TopicUri validateBackendTopicUri(TopicUri topicUri) throws TopicUriSyntaxException {
+        return MemqTopicUri.validate(topicUri);
+    }
+}

--- a/psc/src/main/java/com/pinterest/psc/metadata/creation/PscMetadataClientCreatorManager.java
+++ b/psc/src/main/java/com/pinterest/psc/metadata/creation/PscMetadataClientCreatorManager.java
@@ -7,10 +7,10 @@ import org.reflections.Reflections;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Manages the different {@link PscBackendMetadataClientCreator} implementations and provides a registry of them.
@@ -28,7 +28,7 @@ public class PscMetadataClientCreatorManager {
 
     private static Map<String, List<PscBackendMetadataClientCreator>> findAndRegisterMetadataClientCreators(String packageName) {
         synchronized (PscUtils.lock) {
-            Map<String, List<PscBackendMetadataClientCreator>> backendCreatorRegistry = new HashMap<>();
+            Map<String, List<PscBackendMetadataClientCreator>> backendCreatorRegistry = new TreeMap<>();
             Reflections reflections = new Reflections(packageName.trim());
             Set<Class<?>> annotatedClasses = reflections.getTypesAnnotatedWith(PscMetadataClientCreatorPlugin.class);
             for (Class<?> annotatedClass : annotatedClasses) {

--- a/psc/src/main/java/com/pinterest/psc/metrics/PscMetricRegistryManager.java
+++ b/psc/src/main/java/com/pinterest/psc/metrics/PscMetricRegistryManager.java
@@ -6,7 +6,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
@@ -224,7 +224,7 @@ public class PscMetricRegistryManager {
             if (metricRegistry != null) {
                 metricRegistry.histogram(metricKey,
                         () -> new Histogram(
-                                new SlidingTimeWindowArrayReservoir(1, TimeUnit.MINUTES)
+                                new ExponentiallyDecayingReservoir()
                         )
                 ).update(metricValue);
             }

--- a/psc/src/test/java/com/pinterest/psc/consumer/memq/TestMemqOffsetRoundTrip.java
+++ b/psc/src/test/java/com/pinterest/psc/consumer/memq/TestMemqOffsetRoundTrip.java
@@ -1,0 +1,83 @@
+package com.pinterest.psc.consumer.memq;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that raw Kafka notification offsets survive a round-trip through
+ * the composite MemqOffset encoding used by PscMemqConsumer.
+ *
+ * Bug context: offsetsForTimes / endOffsets / startOffsets were returning raw
+ * Kafka offsets, but seekToOffset decodes them as composite MemqOffsets
+ * (bit-shifting right by 19). Without wrapping via kafkaOffsetToComposite,
+ * a raw offset like 2205646 would be decoded as batch=4 instead of batch=2205646.
+ */
+public class TestMemqOffsetRoundTrip {
+
+    @Test
+    public void testRawKafkaOffsetRoundTrips() {
+        long rawKafkaOffset = 2205646L;
+
+        long composite = new MemqOffset(rawKafkaOffset, 0).toLong();
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(composite);
+
+        assertEquals(rawKafkaOffset, decoded.getBatchOffset());
+        assertEquals(0, decoded.getMessageOffset());
+    }
+
+    @Test
+    public void testRawOffsetWithoutEncodingIsCorrupted() {
+        long rawKafkaOffset = 2205646L;
+
+        // Decoding a raw offset directly (the old bug) produces wrong batch offset
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(rawKafkaOffset);
+
+        // 2205646 >>> 19 = 4, not 2205646
+        assertEquals(4, decoded.getBatchOffset(),
+                "Raw offset decoded without encoding should lose upper bits");
+    }
+
+    @Test
+    public void testSmallOffsetRoundTrips() {
+        long rawKafkaOffset = 42L;
+
+        long composite = new MemqOffset(rawKafkaOffset, 0).toLong();
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(composite);
+
+        assertEquals(rawKafkaOffset, decoded.getBatchOffset());
+        assertEquals(0, decoded.getMessageOffset());
+    }
+
+    @Test
+    public void testZeroOffsetRoundTrips() {
+        long composite = new MemqOffset(0, 0).toLong();
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(composite);
+
+        assertEquals(0, decoded.getBatchOffset());
+        assertEquals(0, decoded.getMessageOffset());
+    }
+
+    @Test
+    public void testLargeOffsetRoundTrips() {
+        long rawKafkaOffset = 10_000_000L;
+
+        long composite = new MemqOffset(rawKafkaOffset, 0).toLong();
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(composite);
+
+        assertEquals(rawKafkaOffset, decoded.getBatchOffset());
+        assertEquals(0, decoded.getMessageOffset());
+    }
+
+    @Test
+    public void testCompositeWithMessageOffsetRoundTrips() {
+        long batchOffset = 500L;
+        int messageOffset = 1234;
+
+        long composite = new MemqOffset(batchOffset, messageOffset).toLong();
+        MemqOffset decoded = MemqOffset.convertPscOffsetToMemqOffset(composite);
+
+        assertEquals(batchOffset, decoded.getBatchOffset());
+        assertEquals(messageOffset, decoded.getMessageOffset());
+    }
+}


### PR DESCRIPTION
Add Memq Metadata Client
Here's a summary of all the changes:

Files created
psc/src/main/java/com/pinterest/psc/metadata/client/memq/PscMemqMetadataClient.java - The main Memq metadata client implementation extending PscBackendMetadataClient. Since Memq doesn't have a dedicated admin client (unlike Kafka's AdminClient), it uses short-lived MemqConsumer instances for all metadata queries. The implementation:

listTopicRns() - throws UnsupportedOperationException since Memq doesn't support listing all topics
describeTopicUris() - creates a consumer per topic, subscribes, and calls getPartition() to discover partitions
listOffsets() - groups partitions by topic, uses getEarliestOffsets() / getLatestOffsets() based on the requested option
listOffsetsForTimestamps() - groups by topic and uses offsetsOfTimestamps()
listOffsetsForConsumerGroup() - creates a consumer with the target consumer group ID and uses committed() per partition
psc/src/main/java/com/pinterest/psc/metadata/creation/PscMemqMetadataClientCreator.java - The plugin creator class annotated with @PscMetadataClientCreatorPlugin(backend = "memq", priority = 1), following the exact same pattern as PscKafkaMetadataClientCreator. It creates and initializes PscMemqMetadataClient instances and validates Memq topic URIs via MemqTopicUri.validate().

psc/src/main/java/com/pinterest/psc/config/PscMetadataClientToMemqConsumerConfigConverter.java - Config converter that extends PscMetadataClientToBackendMetatadataClientConfigCoverter, mapping PSC metadata client configuration to Memq consumer configs (e.g., PSC_METADATA_CLIENT_ID to ConsumerConfigs.CLIENT_ID).

File modified
psc/src/main/java/com/pinterest/psc/consumer/memq/MemqTopicUri.java - Changed the constructor from package-private to public so it can be used from the com.pinterest.psc.metadata.client.memq package (consistent with how KafkaTopicUri has a public constructor).